### PR TITLE
Resolved TCP bind retry issue in source mode and supplemented Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,21 @@ RUN git clone https://github.com/aws-samples/aws-iot-securetunneling-localproxy 
 	cmake ../ && \
 	make
 
+# If you'd like to use this Dockerfile to build your LOCAL revisions to the
+# local proxy source code, uncomment the following three commands and comment
+# out the command above. Otherwise, we'll build the local proxy container
+# with fresh source from the GitHub repo.
+
+#RUN mkdir /home/dependencies/aws-iot-securetunneling-localproxy
+#
+#COPY ./ /home/dependencies/aws-iot-securetunneling-localproxy/
+#
+#RUN cd /home/dependencies/aws-iot-securetunneling-localproxy && \
+#    rm -rf build/ && \
+#    mkdir build && \
+#    cd build && \
+#    cmake ../ && \
+#    make
 
 RUN mkdir -p /home/aws-iot-securetunneling-localproxy && \
 	cd /home/aws-iot-securetunneling-localproxy && \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ This code enables tunneling of a single threaded TCP client / server socket inte
 
 ---
 
-## Building the local proxy
+## Building the local proxy via Docker
+
+### Prerequisites
+
+* Docker 18+
+
+### Running the Docker Build
+
+`./docker-build.sh`
+
+After the Docker build completes, run `./docker-run.sh` to open a shell inside the container created in the
+previous step. Here you can find both the `localproxy` and `localproxytest` binaries.
+
+---
+
+## Building the local proxy from source
 
 ### Prerequisites
 

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -171,6 +171,11 @@ namespace aws { namespace iot { namespace securedtunneling {
                 if (GET_SETTING(settings, WEB_SOCKET_DATA_ERROR_RETRY))
                 {
                     BOOST_LOG_SEV(log, error) << "Error from io_ctx::run(): " << e.what();
+                    if(e.is_local_port_bind_failure() && adapter_config.mode == proxy_mode::SOURCE) {
+                        BOOST_LOG_SEV(log, error) << "Local proxy failed to bind to port " << tac.adapter_config.data_port
+                            << " in source mode. Verify the selected port is not already in use and try again.";
+                        return;
+                    }
                 }
                 else
                 {
@@ -1101,7 +1106,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                             BOOST_LOG_SEV(log, error) << (boost::format("Could not listen on bind address: %1% -- %2%")
                                 % results->endpoint().address().to_string() % listen_ec.message()).str();
                             basic_retry_execute(log, retry_config,
-                                [&tac, &ec]() { throw proxy_exception((boost::format("Failed to listen on bind address %1%:%2%") % tac.bind_address_actual % tac.adapter_config.data_port).str(), ec); });
+                                [&tac, &ec]() { throw proxy_exception((boost::format("Failed to listen on bind address %1%:%2%") % tac.bind_address_actual % tac.adapter_config.data_port).str(), ec, true); });
                         }
                         else
                         {

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -154,7 +154,7 @@ namespace aws { namespace iot { namespace securedtunneling {
     tcp_adapter_proxy::~tcp_adapter_proxy()
     { }
 
-    void tcp_adapter_proxy::run_proxy()
+    int tcp_adapter_proxy::run_proxy()
     {
         BOOST_LOG_SEV(log, info) << "Starting proxy in " << get_proxy_mode_string(adapter_config.mode) << " mode";
         while (true)
@@ -164,7 +164,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             {
                 setup_web_socket(tac);
                 tac.io_ctx.run();
-                return;
+                return EXIT_SUCCESS;
             }
             catch (proxy_exception &e)
             {
@@ -174,7 +174,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                     if(e.is_local_port_bind_failure() && adapter_config.mode == proxy_mode::SOURCE) {
                         BOOST_LOG_SEV(log, error) << "Local proxy failed to bind to port " << tac.adapter_config.data_port
                             << " in source mode. Verify the selected port is not already in use and try again.";
-                        return;
+                        return EXIT_FAILURE;
                     }
                 }
                 else
@@ -1106,7 +1106,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                             BOOST_LOG_SEV(log, error) << (boost::format("Could not listen on bind address: %1% -- %2%")
                                 % results->endpoint().address().to_string() % listen_ec.message()).str();
                             basic_retry_execute(log, retry_config,
-                                [&tac, &ec]() { throw proxy_exception((boost::format("Failed to listen on bind address %1%:%2%") % tac.bind_address_actual % tac.adapter_config.data_port).str(), ec, true); });
+                                [&tac, &listen_ec]() { throw proxy_exception((boost::format("Failed to listen on bind address %1%:%2%") % tac.bind_address_actual % tac.adapter_config.data_port).str(), listen_ec, true); });
                         }
                         else
                         {

--- a/src/TcpAdapterProxy.h
+++ b/src/TcpAdapterProxy.h
@@ -167,7 +167,7 @@ namespace aws { namespace iot { namespace securedtunneling {
         tcp_adapter_proxy(tcp_adapter_proxy const &) = delete;
         tcp_adapter_proxy(tcp_adapter_proxy &&) = default;
 
-        void run_proxy();
+        int run_proxy();
 
     private:
         void setup_tcp_socket(tcp_adapter_context &tac);

--- a/src/TcpAdapterProxy.h
+++ b/src/TcpAdapterProxy.h
@@ -66,10 +66,13 @@ namespace aws { namespace iot { namespace securedtunneling {
             explicit proxy_exception(std::string const & message) : message(message) {}
             proxy_exception(std::string const & message, boost::system::error_code const & ec)
                 : message{ (boost::format("%1%; Underlying boost::system error: [%2%]") % message%ec.message()).str() }, boost_error_code(boost::make_optional(ec)) {}
+            proxy_exception(std::string const & message, boost::system::error_code const & ec, bool const & bind_failure)
+                : proxy_exception(message, ec) { local_port_bind_failure = bind_failure; }
             proxy_exception(boost::system::error_code const & ec)
                 : message{ (boost::format("Boost::System error: [%1%]") % ec.message()).str() }, boost_error_code(boost::make_optional(ec)) {}
             virtual char const * what() const noexcept { return message.c_str(); }
             boost::optional<boost::system::error_code const> error_code() const { return boost_error_code; }
+            bool is_local_port_bind_failure() const { return local_port_bind_failure; }
 
             proxy_exception(proxy_exception const &) = default;
             ~proxy_exception() = default;
@@ -77,6 +80,7 @@ namespace aws { namespace iot { namespace securedtunneling {
         protected:
             std::string                                             message;
             boost::optional<boost::system::error_code const>        boost_error_code;   //boost system error code if the cause
+            bool                                                    local_port_bind_failure;
         };
 
         //this structure is pretty much *the* program visibility of all

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char ** argv)
         {
             set_logging_filter(logging_level);
             tcp_adapter_proxy proxy{ settings, cfg };
-            proxy.run_proxy();
+            return proxy.run_proxy();
         }
     }
     catch (exception &e)


### PR DESCRIPTION
*Description of changes:*
The changes included in this PR address an issue originally reported by @DavidOgunsAWS . When running the local proxy in source mode against a port that is unavailable, the local proxy will attempt to bind to the port an infinite number of times. While this behavior may make sense in destination mode since we're hopeful that we may be able to bind to the remote service, it just doesn't make sense in source mode. This fix resolves the issue and only makes the default (currently 5) attempts to bind to the specified port when in source mode. 

I've also included some updates to the README and some extra lines for the Dockerfile that may assist future developers in using Docker to build the local proxy and leverage the docker build system when making changes to the local proxy source files. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
