### PR TITLE
Add CI build using GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,167 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '*'
+
+env:
+  PACKAGE_NAME: aws-iot-securetunneling-localproxy
+
+jobs:
+  osx:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: 'Checkout'
+    - name: Install brew dependencies
+      run: |
+        brew install openssl zlib cmake wget git
+    - name: Install boost
+      working-directory: ${{ github.workspace }}
+      run: |
+        wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
+        tar xzvf /tmp/boost.tar.gz
+        cd boost_1_69_0
+        ./bootstrap.sh --with-toolset=clang
+        ./b2 install toolset=clang
+    - name: Install protobuf
+      working-directory: ${{ github.workspace }}
+      run: |
+        wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-all-3.6.1.tar.gz -O /tmp/protobuf-all-3.6.1.tar.gz
+        tar xzvf /tmp/protobuf-all-3.6.1.tar.gz
+        cd protobuf-3.6.1
+        mkdir build_make
+        cd build_make
+        cmake ../cmake
+        make
+        make install
+    - name: Install Catch2
+      working-directory: ${{ github.workspace }}
+      run: |
+        git clone https://github.com/catchorg/Catch2.git
+        cd Catch2
+        mkdir build
+        cd build
+        cmake ../
+        make
+        make install
+    - name: Building localproxy
+      working-directory: ${{ github.workspace }}
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1g/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1g/lib/
+        make
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v2
+    - name: Install apt-get dependencies
+      run: |
+        sudo apt-get install -y build-essential git python3-dev
+        sudo apt-get install -y wget tar zlibc libssl-dev openssl cmake python-dev
+        sudo apt-get clean -y
+    - name: Install boost
+      working-directory: ${{ github.workspace }}
+      run: |
+        wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
+        tar xzvf /tmp/boost.tar.gz
+        cd boost_1_69_0
+        ./bootstrap.sh
+        sudo ./b2 install
+    - name: Install protobuf
+      working-directory: ${{ github.workspace }}
+      run: |
+        wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-all-3.6.1.tar.gz -O /tmp/protobuf-all-3.6.1.tar.gz
+        tar xzvf /tmp/protobuf-all-3.6.1.tar.gz
+        cd protobuf-3.6.1
+        mkdir build_make
+        cd build_make
+        cmake ../cmake
+        make
+        sudo make install
+    - name: install Catch2
+      working-directory: ${{ github.workspace }}
+      run: |
+        git clone https://github.com/catchorg/Catch2.git
+        cd Catch2
+        mkdir build
+        cd build
+        cmake ../
+        make
+        sudo make install
+    - name: Building localproxy
+      working-directory: ${{ github.workspace }}
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1g/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1g/lib/
+        make
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Setup developer command prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.1
+          arch: x64
+      - name: Install OpenSSL
+        run: |
+          Invoke-WebRequest "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-win64.zip" -OutFile "nasm-2.15.05-win64.zip"
+          Expand-Archive "nasm-2.15.05-win64.zip" -Force -DestinationPath "C:\NASM"
+          $env:Path += ";C:\NASM\nasm-2.15.05\"
+          git clone https://github.com/openssl/openssl.git
+          cd openssl
+          git checkout OpenSSL_1_1_1-stable
+          perl Configure VC-WIN64A
+          nmake
+          nmake install
+          $env:Path += ";C:\Program Files\OpenSSL\bin"
+      - name: Install Catch2
+        run: |
+          git clone https://github.com/catchorg/Catch2.git
+          cd Catch2
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../
+          nmake
+          nmake install
+      - name: Install zlib
+        run: |
+          git clone -b v1.2.8 https://github.com/madler/zlib.git
+          cd zlib
+          mkdir build
+          cd build
+          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../
+          nmake
+          nmake install
+          $env:Path += ";C:\Program Files (x86)\zlib\bin"
+      - name: Install boost
+        run: |
+          Invoke-WebRequest "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.zip" -OutFile "boost_1_69_0.zip"
+          Expand-Archive "boost_1_69_0.zip" -Force
+          cd .\boost_1_69_0\boost_1_69_0\
+          .\bootstrap.bat
+          .\b2 toolset=msvc-14.1 address-model=64 install define=BOOST_WINAPI_VERSION_WIN10
+      - name: Install protobuf
+        run: |
+          Invoke-WebRequest "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-all-3.6.1.zip" -OutFile "protobuf-all-3.6.1.zip"
+          Expand-Archive protobuf-all-3.6.1.zip
+          cd .\protobuf-all-3.6.1\protobuf-3.6.1\cmake\
+          mkdir build
+          cd build
+          cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ../
+          nmake
+          nmake install
+          $env:Path += ";C:\Program Files (x86)\protobuf\bin"
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+      - name: Build localproxy 
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir build
+          cd build
+          cmake -DWIN32_WINNT=0x0A00 -DBoost_USE_STATIC_LIBS=ON -DCMAKE_PREFIX_PATH="C:\Boost;C:\Program Files (x86)\Catch2;C:\Program Files (x86)\protobuf;C:\Program Files\OpenSSL" -G "Visual Studio 16 2019" -A x64 ..\
+          msbuild localproxy.vcxproj -p:Configuration=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 if (UNIX OR APPLE)
     set(CUSTOM_COMPILER_FLAGS "-O2 -D_FORTIFY_SOURCE=2 -fPIE -Wall -Werror")
     set(TEST_COMPILER_FLAGS "${CUSTOM_COMPILER_FLAGS} -D_AWSIOT_TUNNELING_NO_SSL")
-elseif (WIN32)
+elseif (WIN32 OR MSVC)
     set(CUSTOM_COMPILER_FLAGS "/W4 /DYNAMICBASE /NXCOMPAT /analyze")
     set(TEST_COMPILER_FLAGS "${CUSTOM_COMPILER_FLAGS} /D_AWSIOT_TUNNELING_NO_SSL")
+    add_definitions(-D_WIN32_WINNT=${WIN32_WINNT})
 endif ()
 
 
@@ -87,8 +88,8 @@ set(TEST_SOURCES ${PROJECT_SOURCE_DIR}/test/AdapterTests.cpp ${CORE_SOURCES} ${P
 add_executable(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} ${MAIN_SOURCES})
 add_executable(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${TEST_SOURCES})
 
-#libatomic ensured for all platforms except OSX
-if(NOT APPLE)
+#libatomic ensured for all platforms except OSX and WINDOWS
+if(NOT APPLE AND NOT MSVC)
     target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} atomic)
     target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} atomic)
 endif()

--- a/windows-localproxy-build.md
+++ b/windows-localproxy-build.md
@@ -7,67 +7,65 @@
 * Install the following dependencies (Choose visual studio command prompt based on architecture):
 	* Download and install zlib:
 		* Use Visual Studio native tool command prompt in admin mode.
-		* git clone -b v1.2.8 https://github.com/madler/zlib.git
-		* cd zlib
-		* mkdir build & cd build
-		* cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../
-		* nmake & nmake install (installs zlib inside C:\Program Files (x86)\ )
+		* `git clone -b v1.2.8 https://github.com/madler/zlib.git`
+		* `cd zlib`
+		* `mkdir build`
+		* `cd build`
+		* `cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../`
+		* `nmake`
+		* `nmake install` (installs zlib inside C:\Program Files (x86)\ )
 		* Update PATH environment variable to add the dll for zlib which is inside C:\Program Files (x86)\zlib\bin
 	* Download and install openssl
 		* Use Visual Studio native tool command prompt in admin mode.
-		* git clone https://github.com/openssl/openssl.git
-		* cd openssl
-		* git checkout OpenSSL_1_1_1-stable
-		* perl Configure { VC-WIN32 | VC-WIN64A | VC-WIN64I | VC-CE } (Choose one of the options based on your architecture )
-		* nmake & nmake install (installs OpenSSL inside C:\Program Files\)
+		* `git clone https://github.com/openssl/openssl.git`
+		* `cd openssl`
+		* `git checkout OpenSSL_1_1_1-stable`
+		* `perl Configure { VC-WIN32 | VC-WIN64A | VC-WIN64I | VC-CE }` (Choose one of the options based on your architecture )
+		* `nmake`
+		* `nmake install` (installs OpenSSL inside C:\Program Files\)
 		* Update PATH environment variable to add the dll for openssl which is inside C:\Program Files\OpenSSL\bin
 		* Download and install catch2
 		* Use Visual Studio native tool command prompt in admin mode.
-		* git clone https://github.com/catchorg/Catch2.git
-		* cd Catch2
-		* mkdir build & cd build
-		* cmake -DBUILD_TESTING=OFF -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../ ( Install python if you want to execute test )
-		* nmake & nmake ( install catch2 inside C:\Program Files (x86)\ )
+		* `git clone https://github.com/catchorg/Catch2.git`
+		* `cd Catch2`
+		* `mkdir build`
+		* `cd build`
+		* `cmake -DBUILD_TESTING=OFF -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ../` ( Install python if you want to execute test )
+		* `nmake`
+		* `nmake install` ( install catch2 inside C:\Program Files (x86)\ )
 	* Download and install protobuf
 		* Download from https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-all-3.6.1.tar.gz
 		* Extract protobuf-all-3.6.1.tar.gz
 		* Use Visual Studio native tool command prompt
-		* cd path/to/protobuf-3.6.1
-		* cd cmake
-		* mkdir build & cd build
-		* cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ../
-		* nmake & nmake install ( install protobuf inside C:\Program Files (x86)\ )
+		* `cd path/to/protobuf-3.6.1`
+		* `cd cmake`
+		* `mkdir build`
+		* `cd build`
+		* `cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ../`
+		* `nmake`
+		* `nmake install` ( install protobuf inside C:\Program Files (x86)\ )
 	* Download and install boost
 		* Download from https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
 		* Extract boost_1_69_0.tar.gz
 		* Use Visual Studio native tool command prompt
-		* cd path/to/boost_1_69_0
-		* bootstrap.bat
-		* .\b2 install ( installs boost inside C:\)
+		* `cd path/to/boost_1_69_0`
+		* `bootstrap.bat`
+		* `.\b2 toolset=msvc address-model={32 | 64} install define=BOOST_WINAPI_VERSION_WIN10` ( installs boost inside C:\)
+			* Replace `BOOST_WINAPI_VERSION_WIN10` with the appropriate macro from [here](https://www.boost.org/doc/libs/develop/libs/winapi/doc/html/winapi/config.html)
 	* Download and build aws-iot-securetunneling-localproxy
 		* Use Visual Studio native tool comand prompt in admin mode
-		* git clone https://github.com/aws-samples/aws-iot-securetunneling-localproxy.git
-		* cd aws-iot-securetunneling-localproxy
-		* Edit CmakeList.txt file to make the following changes:
-			* Replace set_property(GLOBAL PROPERTY Boost_USE_STATIC_LIBS ON) by set(Boost_USE_STATIC_LIBS ON)
-			* Comment out line target_link_libraries(\${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} atomic) and target_link_libraries(\${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} atomic) by inserting # infront of those lines.
-			* Replace the following  code block ( Replace WINAPI_VERSION using link https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=vs-2019 ).
-			    ```
-				    elseif (WIN32)
-				     set(CUSTOM_COMPILER_FLAGS "/W4 /DYNAMICBASE /NXCOMPAT /analyze")
-				     set(TEST_COMPILER_FLAGS "${CUSTOM_COMPILER_FLAGS} /D_AWSIOT_TUNNELING_NO_SSL")
-				    endif ()
-                ```
-		     With the following code block:
-             ```	
-              elseif (WIN32)
-                  set(CUSTOM_COMPILER_FLAGS "/W4 /DYNAMICBASE /NXCOMPAT /analyze")
-                  set(TEST_COMPILER_FLAGS "${CUSTOM_COMPILER_FLAGS} /D_AWSIOT_TUNNELING_NO_SSL")
-                  add_definitions(-D_WIN32_WINNT=<WINAPI_VERSION>)
-                  add_definitions(-D_BOOST_USE_WINAPI_VERSION=<WINAPI_VERSION>)
-              endif ()
+		* `git clone https://github.com/aws-samples/aws-iot-securetunneling-localproxy.git`
+		* `cd aws-iot-securetunneling-localproxy`
+		* `mkdir build`
+		* `cd build`
+		* Build the cmake project. Replace <_WIN32_WINNT> with the appropriate value based on [your OS from here](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=vs-2019)
+			* For visual studio 2019
 			```
-		* mkdir build & cd build
-		* cmake -DCMAKE_PREFIX_PATH="C:\Boost;C:\Program Files (x86)\Catch2;C:\Program Files (x86)\protobuf;C:\Program Files\OpenSSL" -G "Visual Studio 15 2017 <Win64/Win32>" ..\
-		* msbuild localproxy.vcxproj -p:Configuration=Release ( builds localproxy.exe inside bin\Release folder )
+			cmake -DWIN32_WINNT=<_WIN32_WINNT> -DBoost_USE_STATIC_LIBS=ON -DCMAKE_PREFIX_PATH="C:\Boost;C:\Program Files (x86)\Catch2;C:\Program Files (x86)\protobuf;C:\Program Files\OpenSSL" -G "Visual Studio 16 2019" -A x64 ..\
+			```
+			* for visual studio 2017
+			```
+			cmake -DWIN32_WINNT=<_WIN32_WINNT> -DBoost_USE_STATIC_LIBS=ON -DCMAKE_PREFIX_PATH="C:\Boost;C:\Program Files (x86)\Catch2;C:\Program Files (x86)\protobuf;C:\Program Files\OpenSSL" -G "Visual Studio 15 2017 <Win64/Win32>" ..\
+			```
+		* `msbuild localproxy.vcxproj -p:Configuration=Release` ( builds localproxy.exe inside bin\Release folder )
 	* Follow [instructions](https://github.com/aws-samples/aws-iot-securetunneling-localproxy) under heading `Security Considerations` to run local proxy on a window OS.


### PR DESCRIPTION
Motivations:
the localproxy is cross-platform so I've added CI script that will build
the localproxy on OSX, Ubuntu and Windows each time a commit is pushed
that way we can use it as a sanity check.

Modifications:
Added the CI script, updated CMakeLists.txt for windows and updated the
windows build instructions.

Testing:
You can check the CI script results here
https://github.com/KareemAliAWS/aws-iot-securetunneling-localproxy/actions/runs/246520629

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
