### PR TITLE
Add pull request template 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 
 ### Modifications
 #### Change summary
-Please describe what changes are included in this CR. 
+Please describe what changes are included in this pull request.
 
 #### Revision diff summary
 If there is more than one revision, please explain what has been changed since the last revision.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1j/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1j/lib/
+        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1k/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1k/lib/
         make
   ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install boost
       working-directory: ${{ github.workspace }}
       run: |
-        wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
+        wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
         tar xzvf /tmp/boost.tar.gz
         cd boost_1_69_0
         ./bootstrap.sh --with-toolset=clang
@@ -66,7 +66,7 @@ jobs:
     - name: Install boost
       working-directory: ${{ github.workspace }}
       run: |
-        wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
+        wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
         tar xzvf /tmp/boost.tar.gz
         cd boost_1_69_0
         ./bootstrap.sh
@@ -140,7 +140,7 @@ jobs:
           $env:Path += ";C:\Program Files (x86)\zlib\bin"
       - name: Install boost
         run: |
-          Invoke-WebRequest "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.zip" -OutFile "boost_1_69_0.zip"
+          Invoke-WebRequest "https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.zip" -OutFile "boost_1_69_0.zip"
           Expand-Archive "boost_1_69_0.zip" -Force
           cd .\boost_1_69_0\boost_1_69_0\
           .\bootstrap.bat

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - cmake ../
   - make
   - sudo make install
-  - wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
+  - wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
   - tar xzf /tmp/boost.tar.gz
   - cd boost_1_69_0
   - ./bootstrap.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget https://www.zlib.net/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz && \
 	make install && \
 	cd /home/dependencies
 
-RUN wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz && \
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz && \
 	tar xzvf /tmp/boost.tar.gz && \
 	cd boost_1_69_0 && \
 	./bootstrap.sh && \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Fedora example:
 
 #### 2. Download and install Boost dependency
 
-    wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
+    wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
     tar xzvf /tmp/boost.tar.gz
     cd boost_1_69_0
     ./bootstrap.sh

--- a/windows-localproxy-build.md
+++ b/windows-localproxy-build.md
@@ -45,8 +45,8 @@
 		* `nmake`
 		* `nmake install` ( install protobuf inside C:\Program Files (x86)\ )
 	* Download and install boost
-		* Download from https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
-		* Extract boost_1_69_0.tar.gz
+		* Download from https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.zip
+		* Extract boost_1_69_0.zip
 		* Use Visual Studio native tool command prompt
 		* `cd path/to/boost_1_69_0`
 		* `bootstrap.bat`


### PR DESCRIPTION
*Description of changes:*
1. Add a pull request template for our repository so that we can standardize the pull request information. 
Following [this instruction](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to create a pull request template. 
1. Update _OPENSSL_ROOT_DIR_ version to 1.1.1k. Otherwise, CI action for Mac OS will fail due to missing OPENSSL_ROOT_DIR error. 
2. Upgrade boost 1.69 URL path. Without this fix, CI action will fail to install boost and throw 403 error.
```
Run wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz
--2021-04-12 16:46:10--  https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
Resolving dl.bintray.com (dl.bintray.com)... 52.12.180.214, 34.214.135.19, 52.43.14.61, ...
Connecting to dl.bintray.com (dl.bintray.com)|52.12.180.214|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2021-04-12 16:46:11 ERROR 403: Forbidden.
``` 
 - Failed CI action output: https://github.com/aws-samples/aws-iot-securetunneling-localproxy/runs/2325936792
 -  Refer https://github.com/boostorg/boost/issues/502 for more details. 

CI test run passed: [test run result](https://github.com/MiaoZhangAWS/aws-iot-securetunneling-localproxy/runs/2328767399)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
