### PR TITLE
Update the openssl version in the CI and boost URL in Dockerfile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: KareemAliAWS
+assignees: 
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: KareemAliAWS
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+
+A clear and concise description of what actually happened.
+
+**Logs**
+
+If applicable, add full logs of errors and outputs to help explain your problem. Preferabbly, you can also [increase the verbosity](https://github.com/aws-samples/aws-iot-securetunneling-localproxy#options-set-via-command-line-arguments), for example to enable debug logs for the localproxy, you can use the cli option `-v 6`
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Ubuntu]
+ - Version [e.g. 16]
+ - Architecture: [e.g. x86-64 or x86-32]
+ - Localproxy commit: [e.g. [8980ea8e0190c7e8fd942f2bce8bfc01aa6a6a52](https://github.com/aws-samples/aws-iot-securetunneling-localproxy/commit/8980ea8e0190c7e8fd942f2bce8bfc01aa6a6a52)]
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1h/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1h/lib/
+        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1k/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1k/lib/
         make
   ubuntu:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget https://www.zlib.net/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz && \
 	make install && \
 	cd /home/dependencies
 
-RUN wget https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz && \
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz -O /tmp/boost.tar.gz && \
 	tar xzvf /tmp/boost.tar.gz && \
 	cd boost_1_69_0 && \
 	./bootstrap.sh && \


### PR DESCRIPTION
### Motivation
- The Docker build was failing due to incorrect boost URL.
- The CI workflow was failing because it needed updating the openssl version.


### Modifications
#### Change summary
Update the openssl version in the CI and boost URL in Dockerfile

### Testing
- Ran the Docker build and made sure it's successful.
- CI test run result: Still in progress.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
