### PR TITLE
Fix issues with running localproxy from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # FROM ubuntu:18.04
 FROM ubuntu:18.04 as builder
+ARG OPENSSL_CONFIG
 
 # Install Prerequisites
 
@@ -37,10 +38,11 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/pr
 	make install && \
 	cd /home/dependencies
 
+
 RUN git clone https://github.com/openssl/openssl.git && \
 	cd openssl && \
 	git checkout OpenSSL_1_1_1-stable && \
-	./Configure linux-generic64 && \
+	./Configure $OPENSSL_CONFIG && \
 	make depend && \
 	make all && \
 	cd /home/dependencies

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This code enables tunneling of a single threaded TCP client / server socket inte
 `./docker-build.sh`
 
 After the Docker build completes, run `./docker-run.sh` to open a shell inside the container created in the
-previous step. Here you can find both the `localproxy` and `localproxytest` binaries.
+previous step, or you can run `./docker-run.sh -p <port_number>` to expose a port from the docker container. Here you can find both the `localproxy` and `localproxytest` binaries. Note that when the localproxy runs in source mode, it binds by default to `localhost`, If you want to access the localproxy from outside the container, make sure to use the option `-b 0.0.0.0` when you run the localproxy from the container so that it binds to `0.0.0.0` since `localhost` can not be access from outside the container.
 
 ---
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
 
-docker build -t aws-iot-securetunneling-localproxy:latest .
+architecture=$(uname -m)
+
+if [ "${architecture}" != aarch64 -a "${architecture}" != arm64 ]; then
+	openssl_config=linux-generic64
+else
+	openssl_config=linux-aarch64
+fi
+
+echo Architecture: $architecture
+echo OpenSSL configurations: $openssl_config
+docker build --build-arg OPENSSL_CONFIG=$openssl_config -t aws-iot-securetunneling-localproxy:latest .

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
 
-docker run --name localproxy --rm -it aws-iot-securetunneling-localproxy:latest bash
+while getopts p: flag
+do
+    case "${flag}" in
+        p) port=${OPTARG};;
+    esac
+done
+
+if [ -z $port ]; then
+	docker run --name localproxy --rm -it aws-iot-securetunneling-localproxy:latest bash;
+else
+	echo Running the container with exposed port: $port
+	docker run --name localproxy --expose=$port -p $port:$port --rm -it aws-iot-securetunneling-localproxy:latest bash;
+fi
+


### PR DESCRIPTION
### Motivation
- Issue number: #43, #45
- fix #43 Adjust Openssl configuration script in Dockerfile: Using linux-generic64 configuration for openssl fails on some aarch64 chips (Apple M1 chip) when trying to use localproxy via docker causing the connection to get disrupted during the handshake so I'm switching to `linux-aarch64` configurations when the architecture is aarch64.
- fix #45 Allowing localproxy source port exposure via docker : To forward traffic from the host machine to the docker container, we need to expose the listening port, and bind the localproxy listener to 0.0.0.0 address since "localhost" address is only accessible from within the container.

### Modification:
Added new build flag to select whether to determine which IPV4 address localproxy should bind to and updated the docker-run.sh script to accept a port as an argument.

### Testing
- #43 test: Using an arm64 machine with Amazon Linux 2 installed, I ran localproxy from docker and had the user who created the issue test the fix on their machine.
- #43 test: 
  1. Ran the localproxy using docker, confirmed it's binding to 0.0.0.0
   and that I can SSH from outside the container (the host).
  2. Ran the localproxy natively, confirmed it's binding to localhost and
   that I can SSH from the host.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
