### PR TITLE
Link boost and protobuf statically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         tar xzvf /tmp/boost.tar.gz
         cd boost_1_76_0
         ./bootstrap.sh --with-toolset=clang
-        ./b2 install toolset=clang
+        ./b2 install toolset=clang link=static
     - name: Install protobuf
       working-directory: ${{ github.workspace }}
       run: |
@@ -70,7 +70,7 @@ jobs:
         tar xzvf /tmp/boost.tar.gz
         cd boost_1_76_0
         ./bootstrap.sh
-        sudo ./b2 install
+        sudo ./b2 install link=static
     - name: Install protobuf
       working-directory: ${{ github.workspace }}
       run: |
@@ -144,7 +144,7 @@ jobs:
           Expand-Archive "boost_1_76_0.zip" -Force
           cd .\boost_1_76_0\boost_1_76_0\
           .\bootstrap.bat
-          .\b2 toolset=msvc-14.2 address-model=64 install define=BOOST_WINAPI_VERSION_WIN10
+          .\b2 toolset=msvc-14.2 address-model=64 install define=BOOST_WINAPI_VERSION_WIN10 link=static
       - name: Install protobuf
         run: |
           cd \

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *build/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_
 	tar xzvf /tmp/boost.tar.gz && \
 	cd boost_1_76_0 && \
 	./bootstrap.sh && \
-	./b2 install && \
+	./b2 install link=static && \
 	cd /home/dependencies
 
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz -O /tmp/protobuf-all-3.17.3.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Fedora example:
     tar xzvf /tmp/boost.tar.gz
     cd boost_1_76_0
     ./bootstrap.sh
-    sudo ./b2 install
+    sudo ./b2 install link=static
 
 #### 3. Download and install Protobuf dependency
 


### PR DESCRIPTION
### Motivation
- Link Boost and protobuf statically to avoid runtime dependency on either library.
- Issue number: #62 


### Modifications
#### Change summary
1. Update the Dockerfile, README.md and CI workflows to build boost with `link=static`

### Testing
1. `docker system prune -a`
2. `./docker-build.sh`
2. `./docker-run.sh`
3. `./localproxy`
  ```
   [2021-08-06T16:56:28.002628]{12}[fatal]   Must specify one and only one of --region/-r or --proxy-endpoint/-e options
  ```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
