### PR TITLE
Switch the docker image to use AL instead of ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1k/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1k/lib/
+        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1m/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1m/lib/
         make
   ubuntu:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-# FROM ubuntu:18.04
-FROM ubuntu:18.04 as builder
+# FROM amazonlinux:latest
+FROM amazonlinux:latest as builder
 ARG OPENSSL_CONFIG
 
 # Install Prerequisites
 
-RUN apt update && apt upgrade -y && \
-	apt install -y git libboost-all-dev autoconf automake \
-	wget libtool curl make g++ unzip cmake libssl-dev
+RUN yum check-update; yum upgrade -y && \
+	yum install -y git boost-devel autoconf automake \
+	wget libtool curl make gcc-c++ unzip cmake3 openssl11-devel \
+	python-devel which
 
 # Install Dependencies
 
@@ -33,7 +34,7 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/p
 	cd protobuf-3.17.3 && \
 	mkdir build && \
 	cd build && \
-	cmake ../cmake && \
+	cmake3 ../cmake && \
 	make && \
 	make install && \
 	cd /home/dependencies
@@ -50,7 +51,7 @@ RUN git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git && \
 	cd Catch2 && \
 	mkdir build && \
 	cd build && \
-	cmake ../ && \
+	cmake3 ../ && \
 	make && \
 	make install && \
 	cd /home/dependencies
@@ -59,7 +60,7 @@ RUN git clone https://github.com/aws-samples/aws-iot-securetunneling-localproxy 
 	cd aws-iot-securetunneling-localproxy && \
 	mkdir build && \
 	cd build && \
-	cmake ../ && \
+	cmake3 ../ && \
 	make
 
 # If you'd like to use this Dockerfile to build your LOCAL revisions to the
@@ -88,19 +89,19 @@ WORKDIR /home/aws-iot-securetunneling-localproxy/
 
 ## Actual docker image
 
-FROM ubuntu:18.04
+FROM amazonlinux:latest
 
 # Install openssl for libssl dependency.
 
-RUN apt update && apt upgrade -y && \
-    apt install -y openssl wget && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+RUN yum check-update; yum upgrade -y && \
+    yum install -y openssl11 wget libatomic && \
+    rm -rf /var/cache/yum && \
+    yum clean all
 
 RUN mkdir -p /home/aws-iot-securetunneling-localproxy/certs && \
     cd /home/aws-iot-securetunneling-localproxy/certs && \
     wget https://www.amazontrust.com/repository/AmazonRootCA1.pem && \
-	openssl rehash ./
+	openssl11 rehash ./
 
 # # Copy the binaries from builder stage.
 


### PR DESCRIPTION
Motivation:

### Motivation
- Ubuntu has some un-patched CVEs 
- Issue number: #68 


### Testing
1. Built the image locally `sudo ./docker-build.sh`
2. Attached my terminal to the docker container `docker run -it aws-iot-securetunneling-localproxy:latest /bin/bash`
3. Ensured localproxy is running successfully.
  ```
bash-4.2# ./localproxy -h
Allowed options:
  -h [ --help ]                   Show help message
  -t [ --access-token ] arg       Client access token
  -e [ --proxy-endpoint ] arg     Endpoint of proxy server with port (if not 
                                  default 443). Example: data.tunneling.iot.us-
                                  east-1.amazonaws.com:443
  -r [ --region ] arg             Endpoint region where tunnel exists. Mutually
                                  exclusive flag with --proxy-endpoint
  -s [ --source-listen-port ] arg Sets the mappings between source listening 
                                  ports and service identifier. Example: 
                                  SSH1=5555 or 5555
  -d [ --destination-app ] arg    Sets the mappings between the 
                                  endpoint(address:port/port) and service 
                                  identifier. Example: SSH1=127.0.0.1:22 or 22
  -b [ --local-bind-address ] arg Assigns a specific local address to bind to 
                                  for listening in source mode or a local 
                                  socket address for destination mode.
  -c [ --capath ] arg             Adds the directory containing certificate 
                                  authority files to be used for performing 
                                  verification
  -k [ --no-ssl-host-verify ]     Turn off SSL host verification
  --export-default-settings arg   Exports the default settings for the TCP 
                                  adapter to the given file as json and exit 
                                  program
  --settings-json arg             Use the input JSON file to apply fine grained
                                  settings.
  --config arg                    Use the supplied configuration file to apply 
                                  CLI args. Actual CLI args override the 
                                  contents of this file
  -v [ --verbose ] arg (=4)       Logging level to standard out. [0, 255] 
                                  (0=off, 1=fatal, 2=error, 3=warning, 4=info, 
                                  5=debug, >=6=trace)
  -m [ --mode ] arg               The mode local proxy will run: src(source) or
                                  dst(destination)
  --config-dir arg                Set the configuration directory where service
                                  identifier mappings are stored. If not 
                                  specified, will read mappings from default 
                                  directory ./config (same directory where 
                                  local proxy binary is running)
  ```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
