### PR TITLE
Ignore .vscode dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 *build/
 .DS_Store
+.vscode/


### PR DESCRIPTION
### Motivation
- VSCode CMake extension created a settings file that showed up as untracked.

### Modifications
#### Change summary
Add `.vscode/` to `.gitignore`

### Testing
N/A, affects `git status` only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
