### PR TITLE
Bump zlib from 1.2.11 to 1.2.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN yum check-update; yum upgrade -y && \
 RUN mkdir /home/dependencies
 WORKDIR /home/dependencies
 
-RUN wget https://www.zlib.net/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz && \
-	tar xzvf /tmp/zlib-1.2.11.tar.gz && \
-	cd zlib-1.2.11 && \
+RUN wget https://www.zlib.net/zlib-1.2.12.tar.gz -O /tmp/zlib-1.2.12.tar.gz && \
+	tar xzvf /tmp/zlib-1.2.12.tar.gz && \
+	cd zlib-1.2.12 && \
 	./configure && \
 	make && \
 	make install && \

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Ubuntu example:
 Fedora example:
 `dnf install zlib`
 
-    wget https://www.zlib.net/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz
-    tar xzvf /tmp/zlib-1.2.11.tar.gz
-    cd zlib-1.2.11
+    wget https://www.zlib.net/zlib-1.2.12.tar.gz -O /tmp/zlib-1.2.12.tar.gz
+    tar xzvf /tmp/zlib-1.2.12.tar.gz
+    cd zlib-1.2.12
     ./configure
     make
     sudo make install


### PR DESCRIPTION
### Motivation
- Bump version of zlib from 1.2.11 to 1.2.1.  
- This represents about 5y of bug fixes since the last patch release. See https://www.zlib.net/ChangeLog.txt


### Modifications
#### Change summary
Please describe what changes are included in this pull request.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
Exercised localproxy built with this change using AWS IoT device client securetunneling feature. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
