### PR TITLE
Update the README and V2WebSocketProtocolGuide

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,6 @@ This is an example command to run the local proxy in destination mode, on a tunn
 
 We recommend starting the destination application or server before starting the destination local proxy to ensure that when the local proxy attempts to connect to the destination port, it will succeed. When the local proxy starts in destination mode, it will first connect to the service, and then begin listening for a new connection request over the tunnel. Upon receiving a request, it will attempt to connect to the configured destination address and port. If successful, it will transmit data between the TCP connection and tunnel bi-directionally. 
 
-If a new instance of destination local proxy starts,  using the same client access token as a existing local proxy that is already connected, the old local proxy will be disconnected. Tunnel connection will be reset and the new tunnel connection will be established with the new instance of the destination local proxy. 
-
 For a multiplexed tunnel, one connection drop or connect will not affect the other connections that share the same tunnel. All connections/streams in a multiplexed tunnel is independent.   
 
 
@@ -298,12 +296,19 @@ After preparing this directory, point to it when running the local proxy with th
 
 #### Runtime environment 
 
-* Avoid using the **-t** argument to pass in the access token. We recommend setting the **AWSIOT_TUNNEL_ACCESS_TOKEN** environment variable to specify the client access token with least visibility
-* Run the local proxy executable with least privileges in the OS or environment
+* Avoid using the **-t** argument to pass in the access token. We recommend setting the **AWSIOT_TUNNEL_ACCESS_TOKEN** environment variable to specify the client access token with the least visibility
+* Run the local proxy executable with the least privileges in the OS or environment
     * 
     * If your client application normally connects to a port less than 1024, this would normally require running the local proxy with admin privileges to listen on the same port. This can be avoided if the client application allows you to override the port to connect to. Choose any available port greater than 1024 for the source local proxy to listen to without administrator access. Then you may direct the client application to connect to that port. e.g. For connecting to a source local proxy with an SSH client, the local proxy can be run with `-s 5000` and the SSH client should be run with `-p 5000`
 * On devices with multiple network interfaces, use the **-b** argument to bind the TCP socket to a specific network address restricting the local proxy to only proxy connections on an intended network
 * Consider running the local proxy on separate hosts, containers, sandboxes, chroot jail, or a virtualized environment
+
+#### Access tokens
+
+* Access tokens are not meant to be re-used.
+* After localproxy uses an access token, it will no longer be valid.
+* You can revoke an existing token and get a new valid token by calling [RotateTunnelAccessToken](https://docs.aws.amazon.com/iot/latest/apireference/API_iot-secure-tunneling_RotateTunnelAccessToken.html).
+* Refer to the [Developer Guide](https://docs.aws.amazon.com/iot/latest/developerguide/iot-secure-tunneling-troubleshooting.html) for troubleshooting connectivity issues that can be due to an invalid token.
 
 ### IPv6 support
 

--- a/V2WebSocketProtocolGuide.md
+++ b/V2WebSocketProtocolGuide.md
@@ -25,16 +25,25 @@ The AWS IoT Secure Tunneling's usage of WebSocket is in part a subprotocol as de
 
 The handshake performed to connect to a AWS IoT Secure Tunneling server is a standard WebSocket protocol handshake with additional requirements on the HTTP request. These requirements ensure proper access to a tunnel given a client access token:
 
--   The tunneling service only accepts connections secured with TLS 1.1 or higher
--   The HTTP path of the upgrade request must be `/tunnel`. Requests made to any other path will result in a 400 HTTP response
--   There must be a URL parameter `local-proxy-mode` specifying the tunnel connection (local proxy) mode. The value of this parameter must be `source` or `destination`
--   There must be an access token specified in the request either via cookie, or an HTTP request header
-    -   Set the access token via HTTP request header named 'access-token' or via cookie named 'awsiot-tunnel-token'
-    -   Only one token value may be present in the request. Supplying multiple values for either the access-token header or the cookie, or both combined will cause the handshake to fail.
-    -   Local proxy mode must match the mode of the access token or the handshake will fail.
--   The HTTP request size must not exceed 4k bytes in length. Requests larger than this will be rejected
--   The 'Sec-WebSocket-Protocol' header must contain at least one valid protocol string based on what is supported by the service
-    -   Valid value: 'aws.iot.securetunneling-2.0'
+- The tunneling service only accepts connections secured with TLS 1.1 or higher
+- The HTTP path of the upgrade request must be `/tunnel`. Requests made to any other path will result in a 400 HTTP response
+- There must be a URL parameter `local-proxy-mode` specifying the tunnel connection (local proxy) mode. The value of this parameter must be `source` or `destination`
+- There must be an access token specified in the request either via cookie, or an HTTP request header
+    - Set the access token via HTTP request header named 'access-token' or via cookie named 'awsiot-tunnel-token'
+    - Only one token value may be present in the request. Supplying multiple values for either the access-token header or the cookie, or both combined will cause the handshake to fail.
+    - Local proxy mode must match the mode of the access token or the handshake will fail.
+- The HTTP request size must not exceed 4k bytes in length. Requests larger than this will be rejected
+- The 'Sec-WebSocket-Protocol' header must contain at least one valid protocol string based on what is supported by the service
+    - Valid value: 'aws.iot.securetunneling-2.0'
+- The AWS IoT Secure Tunneling server accepts a `client-token` header for specifying the client token.
+  - The client token is an added security layer to protect the tunnel by ensuring that only the agent that generated the client token can use a particular access token to connect to a tunnel.
+  - Only one client token value may be present in the request. Supplying multiple values will cause the handshake to fail.
+  - The client token is optional.
+  - The client token must be unique per AWS account
+  - It's recommended to use a UUIDv4 to generate the client token.
+  - The client token can be any string that matches the regex `^[a-zA-Z0-9-]{32,128}$`
+  - If a client token is provided, then local proxy needs to pass the same client token for subsequent retries (This is yet to be implemented in the current version of local proxy)
+  - If a client token is not provided, then the access token will become invalid after a successful handshake, and localproxy won't be able to reconnect using the same access token.
 
 An example URI of where to connect is as follows:
 


### PR DESCRIPTION
Motivation:


### Motivation
- AWS IoT secure tunneling is adding security enhancement to the access tokens so this update is for the README and websocket protocol with those changes.
- Issue number: N/A


### Modifications
#### Change summary
Documentation update for the new security enhancements that are relevant to localproxy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
