### PR TITLE
fetaure of adding client-token in UUIDv4 format value via env variable or via -l commandline para same as access-token

### DIFF
--- a/src/LocalproxyConfig.h
+++ b/src/LocalproxyConfig.h
@@ -67,6 +67,10 @@ namespace aws {
                  */
                 bool                                    is_web_proxy_using_tls { };
                 /**
+                 * The tunnel client token which must be provided when they open the tunnel.
+                 */
+                std::string                             client_token { };
+                /**
                  * The tunnel access token which the user gets when they open the tunnel.
                  */
                 std::string                             access_token { };

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -42,6 +42,7 @@ namespace aws { namespace iot { namespace securedtunneling {
 
     char const * const PROXY_MODE_QUERY_PARAM = "local-proxy-mode";
     char const * const ACCESS_TOKEN_HEADER = "access-token";
+    char const * const CLIENT_TOKEN_HEADER = "client-token";
     char const * const SOURCE_PROXY_MODE = "source";
     char const * const DESTINATION_PROXY_MODE = "destination";
     char const * const LOCALHOST_IP = "127.0.0.1";
@@ -721,6 +722,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                                                     {
                                                         request.set(boost::beast::http::field::sec_websocket_protocol, GET_SETTING(settings, WEB_SOCKET_SUBPROTOCOL));
                                                         request.set(ACCESS_TOKEN_HEADER, tac.adapter_config.access_token.c_str());
+                                                        request.set(CLIENT_TOKEN_HEADER, tac.adapter_config.client_token.c_str());
                                                         request.set(boost::beast::http::field::user_agent, user_agent_string);
                                                         BOOST_LOG_SEV(log, trace) << "Web socket ugprade request(*not entirely final):\n" << get_token_filtered_request(request);
                                                     },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ using aws::iot::securedtunneling::get_region_endpoint;
 using aws::iot::securedtunneling::settings::apply_region_overrides;
 
 char const * const TOKEN_ENV_VARIABLE = "AWSIOT_TUNNEL_ACCESS_TOKEN";
+char const * const CLIENT_TOKEN_ENV_VARIABLE = "AWSIOT_TUNNEL_CLIENT_TOKEN";
 char const * const ENDPOINT_ENV_VARIABLE = "AWSIOT_TUNNEL_ENDPOINT";
 char const * const REGION_ENV_VARIABLE = "AWSIOT_TUNNEL_REGION";
 char const * const WEB_PROXY_ENV_VARIABLE = "HTTPS_PROXY";
@@ -143,6 +144,7 @@ bool process_cli(int argc, char ** argv, LocalproxyConfig &cfg, ptree &settings,
     cliargs_desc.add_options()
         ("help,h", "Show help message")
         ("access-token,t", value<string>()->required(), "Client access token")
+        ("client-token,l", value<string>()->required(), "Client token")
         ("proxy-endpoint,e", value<string>(), "Endpoint of proxy server with port (if not default 443). Example: data.tunneling.iot.us-east-1.amazonaws.com:443")
         ("region,r", value<string>(), "Endpoint region where tunnel exists. Mutually exclusive flag with --proxy-endpoint")
         ("source-listen-port,s", value<string>(), "Sets the mappings between source listening ports and service identifier. Example: SSH1=5555 or 5555")
@@ -176,6 +178,7 @@ bool process_cli(int argc, char ** argv, LocalproxyConfig &cfg, ptree &settings,
     init_logging(logging_level);
 
     bool token_cli_warning = vm.count("access-token") != 0;
+    bool client_token_cli_warning = vm.count("client-token") != 0;
 
     //dont allow above settings to be impacted by configuration file or environment variable parsers
     if (vm.count("config"))
@@ -188,6 +191,8 @@ bool process_cli(int argc, char ** argv, LocalproxyConfig &cfg, ptree &settings,
         {
             if (name == TOKEN_ENV_VARIABLE)
                 return "access-token";
+            if (name == CLIENT_TOKEN_ENV_VARIABLE)
+                return "client-token";
             if (name == ENDPOINT_ENV_VARIABLE)
                 return "proxy-endpoint";
             if (name == REGION_ENV_VARIABLE)
@@ -215,6 +220,12 @@ bool process_cli(int argc, char ** argv, LocalproxyConfig &cfg, ptree &settings,
         BOOST_LOG_TRIVIAL(warning) << "Found access token supplied via CLI arg. Consider using environment variable " << TOKEN_ENV_VARIABLE << " instead";
     }
     cfg.access_token = vm["access-token"].as<string>();
+    
+    if (client_token_cli_warning)
+    {
+        BOOST_LOG_TRIVIAL(warning) << "Found client token supplied via CLI arg. Consider using environment variable " << CLIENT_TOKEN_ENV_VARIABLE << " instead";
+    }
+    cfg.client_token = vm["client-token"].as<string>();
 
     string proxy_endpoint = vm.count("proxy-endpoint") == 1 ? vm["proxy-endpoint"].as<string>() :
         get_region_endpoint(vm["region"].as<string>(), settings);


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
Hi All,
Due to recent changes from AWS-Secure-Tunneling feature we are not able to reuse the tunnel till we provide a client-token in UUIDV4 format so that sever can remember it for the next time. In this PR we have implemented that feature. We have already created issues and asked about it in the past.

- References: 
https://github.com/aws-samples/aws-iot-securetunneling-localproxy/blob/eb951de124cabfc2f7d373407556896ac805c935/V2WebSocketProtocolGuide.md?plain=1#L45

- Issue number: 
#85 
#84 


### Modifications
#### Change summary
- most of changes are similarly implanted as previous client-access-token (taken as reference)
- just added new parameter client-token which can be also passed from outside (command-line OR env-variable)
- that client-token will be added to the end of HTTP request same as access-token.
- that's it.


### Testing
 **Is your change tested?**
  Yes.

 **Please list your testing steps and test results.** 
- connected the mqtt-client
- created a new Secure-Tunnel
- got the access-token
- generated new client-token in UUIDV4 format
- supplied all the para in described format like given below
- repeated the same process again after disconnecting localproxy many times and it works.
(previously it was not possible to reconnect after you disconnect for the first time.)

```
# via Commandline 
./localproxy  -r eu-west-1 -d 22 -t xxxxxxxxxxxxxxxxxxxxxxxxxxx -l 514c075b-a407-4d59-9bce-cb82e5e75868

# via Env Variable
AWSIOT_TUNNEL_CLIENT_TOKEN=514c075b-a407-4d59-9bce-cb82e5e75869  AWSIOT_TUNNEL_CLIENT_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxx ./localproxy  -r eu-west-1 -d 22
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
