### PR TITLE
fix random test failure due to thread not finishing

### DIFF
--- a/test/AdapterTests.cpp
+++ b/test/AdapterTests.cpp
@@ -351,8 +351,8 @@ TEST_CASE( "Test destination mode", "[destination]") {
     this_thread::sleep_for(chrono::milliseconds(IO_PAUSE_MS));
 
     // Verify destination app is connected
-    REQUIRE( accepted );
     tcp_accept_thread.join();
+    REQUIRE( accepted );
 
     // Simulate sending data messages from destination app
     uint8_t read_buffer[READ_BUFFER_SIZE];
@@ -371,27 +371,6 @@ TEST_CASE( "Test destination mode", "[destination]") {
     {
     return (msg.type() == com::amazonaws::iot::securedtunneling::Message_Type_STREAM_RESET) && msg.streamid() == 1;
     });
-    destination_socket.close();
-
-    accepted = false;
-    tcp_accept_thread = std::thread{[&acceptor, &destination_socket, &accepted]()
-                                    {
-                                        acceptor.accept(destination_socket);
-                                        accepted = true;
-                                    }};
-    ws_server.deliver_message(ws_server_message);
-    this_thread::sleep_for(chrono::milliseconds(IO_PAUSE_MS));
-    REQUIRE( accepted );
-    tcp_accept_thread.join();
-
-   // Simulate sending data messages from destination app
-    for(int i = 0; i < 5; ++i)
-    {
-    string const test_string = (boost::format("test message: %1%") % i).str();
-    destination_socket.send(boost::asio::buffer(test_string));
-    destination_socket.read_some(boost::asio::buffer(reinterpret_cast<void *>(read_buffer), READ_BUFFER_SIZE));
-    CHECK( string(reinterpret_cast<char *>(read_buffer)) == test_string );
-    }
 
     //instruct websocket to close on client
     ws_server.close_client("test_closure", boost::beast::websocket::internal_error); //need to perform write to trigger close

--- a/test/WebProxyAdapterTests.cpp
+++ b/test/WebProxyAdapterTests.cpp
@@ -16,12 +16,16 @@
 
 using namespace std;
 
+
 namespace aws {
     namespace iot {
         namespace securedtunneling {
             namespace test {
                 constexpr char LOCALHOST[] = "127.0.0.1";
                 constexpr int IO_PAUSE_MS = 1000;
+                constexpr int IO_TIMEOUT_MS = 10000;
+                mutex m;
+                condition_variable cv;
                 unsigned short get_available_port() {
                     boost::asio::io_context io_ctx { };
                     tcp::acceptor acceptor(io_ctx);
@@ -69,6 +73,7 @@ namespace aws {
                         auto on_tcp_tunnel =
                                 [this](const boost::system::error_code& ec_response) {
                                     ec = ec_response;
+                                    cv.notify_one();
                                 };
                         http_server_thread = make_unique<thread>([this]() { http_server.run(); });
                         https_proxy_adapter_thread = make_unique<thread>([this, on_tcp_tunnel]() {
@@ -89,7 +94,8 @@ namespace aws {
                     cout << "Test HTTPS proxy adapter base case with no credentials" << endl;
                     TestContext test_context{};
                     test_context.start();
-                    this_thread::sleep_for(chrono::microseconds(IO_PAUSE_MS));
+                    std::unique_lock<mutex> lk(m);
+                    cv.wait_for(lk, chrono::milliseconds(IO_TIMEOUT_MS));
                     REQUIRE(test_context.ec.message() == WebProxyAdapterErrc_category().message((int) WebProxyAdapterErrc::Success));
                     REQUIRE(static_cast<WebProxyAdapterErrc>(test_context.ec.value()) == WebProxyAdapterErrc::Success);
                     test_context.stop();
@@ -99,7 +105,8 @@ namespace aws {
                     cout << "Test HTTPS proxy adapter handling of valid credentials response" << endl;
                     TestContext test_context{username + ":" + password};
                     test_context.start();
-                    this_thread::sleep_for(chrono::microseconds(IO_PAUSE_MS));
+                    std::unique_lock<mutex> lk(m);
+                    cv.wait_for(lk, chrono::milliseconds(IO_TIMEOUT_MS));
                     REQUIRE(test_context.ec.message() == WebProxyAdapterErrc_category().message((int) WebProxyAdapterErrc::Success));
                     REQUIRE(static_cast<WebProxyAdapterErrc>(test_context.ec.value()) == WebProxyAdapterErrc::Success);
                     test_context.stop();
@@ -109,7 +116,8 @@ namespace aws {
                     cout << "Test HTTPS proxy adapter handling of bad credentials response" << endl;
                     TestContext test_context{username + "a:" + password};
                     test_context.start();
-                    this_thread::sleep_for(chrono::microseconds(IO_PAUSE_MS));
+                    std::unique_lock<mutex> lk(m);
+                    cv.wait_for(lk, chrono::milliseconds(IO_TIMEOUT_MS));
                     REQUIRE(test_context.ec.message() == WebProxyAdapterErrc_category().message((int) WebProxyAdapterErrc::ClientError));
                     REQUIRE(static_cast<WebProxyAdapterErrc>(test_context.ec.value()) == WebProxyAdapterErrc::ClientError);
                     test_context.stop();
@@ -119,7 +127,8 @@ namespace aws {
                     cout << "Test HTTPS proxy adapter handling of 500 response" << endl;
                     TestContext test_context{"500"};
                     test_context.start();
-                    this_thread::sleep_for(chrono::microseconds(IO_PAUSE_MS));
+                    std::unique_lock<mutex> lk(m);
+                    cv.wait_for(lk, chrono::milliseconds(IO_TIMEOUT_MS));
                     REQUIRE(test_context.ec.message() == WebProxyAdapterErrc_category().message((int) WebProxyAdapterErrc::ServerError));
                     REQUIRE(static_cast<WebProxyAdapterErrc>(test_context.ec.value()) == WebProxyAdapterErrc::ServerError);
                     test_context.stop();
@@ -129,7 +138,8 @@ namespace aws {
                     cout << "Test HTTPS proxy adapter handling of 100 response" << endl;
                     TestContext test_context{"100"};
                     test_context.start();
-                    this_thread::sleep_for(chrono::microseconds(IO_PAUSE_MS));
+                    std::unique_lock<mutex> lk(m);
+                    cv.wait_for(lk, chrono::milliseconds(IO_TIMEOUT_MS));
                     REQUIRE(test_context.ec.message() == WebProxyAdapterErrc_category().message((int) WebProxyAdapterErrc::OtherHttpError));
                     REQUIRE(static_cast<WebProxyAdapterErrc>(test_context.ec.value()) == WebProxyAdapterErrc::OtherHttpError);
                     test_context.stop();
@@ -139,7 +149,8 @@ namespace aws {
                     cout << "Test HTTPS proxy adapter handling of 300 response" << endl;
                     TestContext test_context{"300"};
                     test_context.start();
-                    this_thread::sleep_for(chrono::microseconds(IO_PAUSE_MS));
+                    std::unique_lock<mutex> lk(m);
+                    cv.wait_for(lk, chrono::milliseconds(IO_TIMEOUT_MS));
                     REQUIRE(test_context.ec.message() == WebProxyAdapterErrc_category().message((int) WebProxyAdapterErrc::RedirectionError));
                     REQUIRE(static_cast<WebProxyAdapterErrc>(test_context.ec.value()) == WebProxyAdapterErrc::RedirectionError);
                     test_context.stop();

--- a/test/WebProxyAdapterTests.cpp
+++ b/test/WebProxyAdapterTests.cpp
@@ -22,7 +22,6 @@ namespace aws {
         namespace securedtunneling {
             namespace test {
                 constexpr char LOCALHOST[] = "127.0.0.1";
-                constexpr int IO_PAUSE_MS = 1000;
                 constexpr int IO_TIMEOUT_MS = 10000;
                 mutex m;
                 condition_variable cv;


### PR DESCRIPTION
### Motivation
- Fixed getting random pass/fail when running ./localproxytest using docker 
- Issue number: #73 


### Modifications
#### Change summary
Using `conditional_variable` to hold the main thread until the supporting thread is finished

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
