### PR TITLE
Add option for client-token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,11 +304,21 @@ After preparing this directory, point to it when running the local proxy with th
 * Consider running the local proxy on separate hosts, containers, sandboxes, chroot jail, or a virtualized environment
 
 #### Access tokens
-
-* Access tokens are not meant to be re-used.
-* After localproxy uses an access token, it will no longer be valid.
+* After localproxy uses an access token, it will no longer be valid without an accompanying Client Token.
 * You can revoke an existing token and get a new valid token by calling [RotateTunnelAccessToken](https://docs.aws.amazon.com/iot/latest/apireference/API_iot-secure-tunneling_RotateTunnelAccessToken.html).
 * Refer to the [Developer Guide](https://docs.aws.amazon.com/iot/latest/developerguide/iot-secure-tunneling-troubleshooting.html) for troubleshooting connectivity issues that can be due to an invalid token.
+
+#### Client Tokens
+* The client token is an added security layer to protect the tunnel by ensuring that only the agent that generated the client token can use a particular access token to connect to a tunnel. 
+* Only one client token value may be present in the request. Supplying multiple values will cause the handshake to fail.
+* The client token is optional.
+* The client token must be unique across all the open tunnels per AWS account
+* It's recommended to use a UUIDv4 to generate the client token.
+* The client token can be any string that matches the regex `^[a-zA-Z0-9-]{32,128}$`
+* If a client token is provided, then local proxy needs to pass the same client token for subsequent retries (This is yet to be implemented in the current version of local proxy)
+* If a client token is not provided, then the access token will become invalid after a successful handshake, and localproxy won't be able to reconnect using the same access token.
+* The Client Token may be passed using the **-i** argument from the command line or setting the **AWSIOT_CLIENT_TOKEN** environment variable.
+
 
 ### IPv6 support
 

--- a/README.md
+++ b/README.md
@@ -313,11 +313,11 @@ After preparing this directory, point to it when running the local proxy with th
 * Only one client token value may be present in the request. Supplying multiple values will cause the handshake to fail.
 * The client token is optional.
 * The client token must be unique across all the open tunnels per AWS account
-* It's recommended to use a UUIDv4 to generate the client token.
+* It's recommended to use a UUID to generate the client token.
 * The client token can be any string that matches the regex `^[a-zA-Z0-9-]{32,128}$`
 * If a client token is provided, then local proxy needs to pass the same client token for subsequent retries (This is yet to be implemented in the current version of local proxy)
 * If a client token is not provided, then the access token will become invalid after a successful handshake, and localproxy won't be able to reconnect using the same access token.
-* The Client Token may be passed using the **-i** argument from the command line or setting the **AWSIOT_CLIENT_TOKEN** environment variable.
+* The Client Token may be passed using the **-i** argument from the command line or setting the **AWSIOT_TUNNEL_CLIENT_TOKEN** environment variable.
 
 
 ### IPv6 support

--- a/src/LocalproxyConfig.h
+++ b/src/LocalproxyConfig.h
@@ -72,6 +72,10 @@ namespace aws {
                 std::string                             access_token { };
                 proxy_mode                              mode{ proxy_mode::UNKNOWN };
                 /**
+                 * A unique client-token to ensure only the agent which generated the token may connect to a tunnel
+                 */
+                std::string                             client_token;
+                /**
                  * local address to bind to for listening in source mode or a local socket address for destination mode,
                  * defaults localhost.
                  */

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -42,6 +42,7 @@ namespace aws { namespace iot { namespace securedtunneling {
 
     char const * const PROXY_MODE_QUERY_PARAM = "local-proxy-mode";
     char const * const ACCESS_TOKEN_HEADER = "access-token";
+    char const * const CLIENT_TOKEN_HEADER = "client-token";
     char const * const SOURCE_PROXY_MODE = "source";
     char const * const DESTINATION_PROXY_MODE = "destination";
     char const * const LOCALHOST_IP = "127.0.0.1";
@@ -52,7 +53,6 @@ namespace aws { namespace iot { namespace securedtunneling {
     std::set<std::uint32_t> MESSAGE_TYPES_VALIDATING_STREAM_ID {
         com::amazonaws::iot::securedtunneling::Message_Type_DATA,
         com::amazonaws::iot::securedtunneling::Message_Type_STREAM_RESET};
-
 
     std::string get_region_endpoint(std::string const &region, boost::property_tree::ptree const &settings)
     {
@@ -721,6 +721,10 @@ namespace aws { namespace iot { namespace securedtunneling {
                                                     {
                                                         request.set(boost::beast::http::field::sec_websocket_protocol, GET_SETTING(settings, WEB_SOCKET_SUBPROTOCOL));
                                                         request.set(ACCESS_TOKEN_HEADER, tac.adapter_config.access_token.c_str());
+                                                        if(!tac.adapter_config.client_token.empty())
+                                                        {
+                                                            request.set(CLIENT_TOKEN_HEADER, tac.adapter_config.client_token.c_str());
+                                                        }
                                                         request.set(boost::beast::http::field::user_agent, user_agent_string);
                                                         BOOST_LOG_SEV(log, trace) << "Web socket ugprade request(*not entirely final):\n" << get_token_filtered_request(request);
                                                     },

--- a/src/TcpAdapterProxy.h
+++ b/src/TcpAdapterProxy.h
@@ -19,6 +19,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <boost/uuid/uuid.hpp>
 #include "ProxySettings.h"
 #include "TcpConnection.h"
 #include "TcpServer.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,17 +52,11 @@ using aws::iot::securedtunneling::get_region_endpoint;
 using aws::iot::securedtunneling::settings::apply_region_overrides;
 
 char const * const ACCESS_TOKEN_ENV_VARIABLE = "AWSIOT_TUNNEL_ACCESS_TOKEN";
-char const * const CLIENT_TOKEN_ENV_VARIABLE = "AWSIOT_CLIENT_TOKEN";
+char const * const CLIENT_TOKEN_ENV_VARIABLE = "AWSIOT_TUNNEL_CLIENT_TOKEN";
 char const * const ENDPOINT_ENV_VARIABLE = "AWSIOT_TUNNEL_ENDPOINT";
 char const * const REGION_ENV_VARIABLE = "AWSIOT_TUNNEL_REGION";
 char const * const WEB_PROXY_ENV_VARIABLE = "HTTPS_PROXY";
 char const * const web_proxy_env_variable = "https_proxy";
-
-bool validate_client_token(const string client_token)
-{
-    static const boost::regex e("^[a-zA-Z0-9-]{32,128}$");
-    return boost::regex_match(client_token, e);
-}
 
 tuple<string, uint16_t> get_host_and_port(string const & endpoint, uint16_t default_port)
 {
@@ -232,13 +226,7 @@ bool process_cli(int argc, char ** argv, LocalproxyConfig &cfg, ptree &settings,
 
     if (vm.count("client-token") != 0)
     {
-        string client_token = vm["client-token"].as<string>();
-        if(!validate_client_token(client_token))
-        {
-            BOOST_LOG_TRIVIAL(fatal) << "Provided Client Token does not conform to required pattern: ^[a-zA-Z0-9-]{32,128}$";
-            return false;
-        }
-        cfg.client_token = client_token;
+        cfg.client_token = vm["client-token"].as<string>();
     }
 
     string proxy_endpoint = vm.count("proxy-endpoint") == 1 ? vm["proxy-endpoint"].as<string>() :


### PR DESCRIPTION
### Motivation

https://github.com/aws-samples/aws-iot-securetunneling-localproxy/blob/eb951de124cabfc2f7d373407556896ac805c935/V2WebSocketProtocolGuide.md?plain=1#L38-L46

- Issue number: https://github.com/aws-samples/aws-iot-securetunneling-localproxy/issues/85


### Modifications
#### Change summary
Added support for client-token header

### Testing
Added a unit test
Manually tested by connecting to tunnel repeatedly with same access token.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
