### PR TITLE
[CVE-2022-37434] Bump zlib and zlibc versions to 1.12.13 addressing l…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           nmake install
       - name: Install zlib
         run: |
-          git clone -b v1.2.8 https://github.com/madler/zlib.git
+          git clone -b v1.2.13 https://github.com/madler/zlib.git
           cd zlib
           mkdir build
           cd build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN yum check-update; yum upgrade -y && \
 RUN mkdir /home/dependencies
 WORKDIR /home/dependencies
 
-RUN wget https://www.zlib.net/zlib-1.2.12.tar.gz -O /tmp/zlib-1.2.12.tar.gz && \
-	tar xzvf /tmp/zlib-1.2.12.tar.gz && \
-	cd zlib-1.2.12 && \
+RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
+	cd zlib-1.2.13 && \
 	./configure && \
 	make && \
 	make install && \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ previous step, or you can run `./docker-run.sh -p <port_number>` to expose a por
 * Development libraries required:
     * Boost 1.76
     * Protobuf 3.17.x
-    * zlib
+    * zlib 1.12.13+
     * OpenSSL 1.0+
     * Catch2 test framework
 * Stage a dependency build directory and change directory into it:
@@ -54,9 +54,9 @@ Ubuntu example:
 Fedora example:
 `dnf install zlib`
 
-    wget https://www.zlib.net/zlib-1.2.12.tar.gz -O /tmp/zlib-1.2.12.tar.gz
-    tar xzvf /tmp/zlib-1.2.12.tar.gz
-    cd zlib-1.2.12
+    wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz
+    tar xzvf /tmp/zlib-1.2.13.tar.gz
+    cd zlib-1.2.13
     ./configure
     make
     sudo make install

--- a/windows-localproxy-build.md
+++ b/windows-localproxy-build.md
@@ -7,7 +7,7 @@
 * Install the following dependencies (Choose visual studio command prompt based on architecture):
 	* Download and install zlib:
 		* Use Visual Studio native tool command prompt in admin mode.
-		* `git clone -b v1.2.8 https://github.com/madler/zlib.git`
+		* `git clone -b v1.2.13 https://github.com/madler/zlib.git`
 		* `cd zlib`
 		* `mkdir build`
 		* `cd build`


### PR DESCRIPTION
…atest vulnerability

### Motivation
- Please give a brief description for the background of this change.
- Issue number: 


### Modifications
#### Change summary
Please describe what changes are included in this pull request.

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
