### PR TITLE
Fix compatibility with device client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1q/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1q/lib/
+          cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1s/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1s/lib/
           make
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,96 +14,109 @@ env:
 jobs:
   osx:
     runs-on: macos-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
-    - uses: actions/checkout@v2
-      name: 'Checkout'
-    - name: Install brew dependencies
-      run: |
-        brew install openssl@1.1 zlib cmake wget
-    - name: Install boost
-      working-directory: ${{ github.workspace }}
-      run: |
-        wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -O /tmp/boost.tar.gz
-        tar xzvf /tmp/boost.tar.gz
-        cd boost_1_76_0
-        ./bootstrap.sh --with-toolset=clang
-        ./b2 install toolset=clang link=static
-    - name: Install protobuf
-      working-directory: ${{ github.workspace }}
-      run: |
-        wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz -O /tmp/protobuf-all-3.17.3.tar.gz
-        tar xzvf /tmp/protobuf-all-3.17.3.tar.gz
-        cd protobuf-3.17.3
-        mkdir build_make
-        cd build_make
-        cmake ../cmake
-        make
-        make install
-    - name: Install Catch2
-      working-directory: ${{ github.workspace }}
-      run: |
-        git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git
-        cd Catch2
-        mkdir build
-        cd build
-        cmake ../
-        make
-        make install
-    - name: Building localproxy
-      working-directory: ${{ github.workspace }}
-      run: |
-        mkdir build
-        cd build
-        cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1q/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1q/lib/
-        make
+      - uses: actions/checkout@v2
+        name: 'Checkout'
+      - name: Install brew dependencies
+        run: |
+          brew install openssl@1.1 zlib cmake wget
+      - name: Install boost
+        working-directory: ${{ github.workspace }}
+        run: |
+          wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -O /tmp/boost.tar.gz
+          tar xzvf /tmp/boost.tar.gz
+          cd boost_1_76_0
+          ./bootstrap.sh --with-toolset=clang
+          ./b2 install toolset=clang link=static
+      - name: Install protobuf
+        working-directory: ${{ github.workspace }}
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz -O /tmp/protobuf-all-3.17.3.tar.gz
+          tar xzvf /tmp/protobuf-all-3.17.3.tar.gz
+          cd protobuf-3.17.3
+          mkdir build_make
+          cd build_make
+          cmake ../cmake
+          make
+          make install
+      - name: Install Catch2
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git
+          cd Catch2
+          mkdir build
+          cd build
+          cmake ../
+          make
+          make install
+      - name: Building localproxy
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1q/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1q/lib/
+          make
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: localproxy-mac
+          path: ${{ github.workspace }}/build/bin/localproxy
   ubuntu:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
-    - name: 'Checkout'
-      uses: actions/checkout@v2
-    - name: Install apt-get dependencies
-      run: |
-        sudo apt-get install -y build-essential git python3-dev
-        sudo apt-get install -y wget tar zlib1g-dev libssl-dev openssl cmake
-        sudo apt-get clean -y
-    - name: Install boost
-      working-directory: ${{ github.workspace }}
-      run: |
-        wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -O /tmp/boost.tar.gz
-        tar xzvf /tmp/boost.tar.gz
-        cd boost_1_76_0
-        ./bootstrap.sh
-        sudo ./b2 install link=static
-    - name: Install protobuf
-      working-directory: ${{ github.workspace }}
-      run: |
-        wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz -O /tmp/protobuf-all-3.17.3.tar.gz
-        tar xzvf /tmp/protobuf-all-3.17.3.tar.gz
-        cd protobuf-3.17.3
-        mkdir build_make
-        cd build_make
-        cmake ../cmake
-        make
-        sudo make install
-    - name: install Catch2
-      working-directory: ${{ github.workspace }}
-      run: |
-        git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git
-        cd Catch2
-        mkdir build
-        cd build
-        cmake ../
-        make
-        sudo make install
-    - name: Building localproxy
-      working-directory: ${{ github.workspace }}
-      run: |
-        mkdir build
-        cd build
-        cmake ..
-        make
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+      - name: Install apt-get dependencies
+        run: |
+          sudo apt-get install -y build-essential git python3-dev
+          sudo apt-get install -y wget tar zlibc libssl-dev openssl cmake python-dev
+          sudo apt-get clean -y
+      - name: Install boost
+        working-directory: ${{ github.workspace }}
+        run: |
+          wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -O /tmp/boost.tar.gz
+          tar xzvf /tmp/boost.tar.gz
+          cd boost_1_76_0
+          ./bootstrap.sh
+          sudo ./b2 install link=static
+      - name: Install protobuf
+        working-directory: ${{ github.workspace }}
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz -O /tmp/protobuf-all-3.17.3.tar.gz
+          tar xzvf /tmp/protobuf-all-3.17.3.tar.gz
+          cd protobuf-3.17.3
+          mkdir build_make
+          cd build_make
+          cmake ../cmake
+          make
+          sudo make install
+      - name: install Catch2
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone --branch v2.13.6 https://github.com/catchorg/Catch2.git
+          cd Catch2
+          mkdir build
+          cd build
+          cmake ../
+          make
+          sudo make install
+      - name: Building localproxy
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: localproxy-ubuntu
+          path: ${{ github.workspace }}/build/bin/localproxy
   windows:
     runs-on: windows-2019
+    if: (github.event_name == 'push') || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository))
     steps:
       - name: Setup developer command prompt
         uses: ilammy/msvc-dev-cmd@v1
@@ -169,3 +182,8 @@ jobs:
           cd build
           cmake -DWIN32_WINNT=0x0A00 -DBoost_USE_STATIC_LIBS=ON -DCMAKE_PREFIX_PATH="C:\Boost;C:\Program Files (x86)\Catch2;C:\Program Files (x86)\protobuf;C:\Program Files\OpenSSL" -G "Visual Studio 16 2019" -A x64 ..\
           msbuild localproxy.vcxproj -p:Configuration=Release
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: localproxy-windows
+          path: ${{ github.workspace }}\build\bin\Release\localproxy.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install apt-get dependencies
         run: |
           sudo apt-get install -y build-essential git python3-dev
-          sudo apt-get install -y wget tar zlibc libssl-dev openssl cmake python-dev
+          sudo apt-get install -y wget tar zlib1g-dev libssl-dev openssl cmake
           sudo apt-get clean -y
       - name: Install boost
         working-directory: ${{ github.workspace }}

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1556,10 +1556,9 @@ namespace aws { namespace iot { namespace securedtunneling {
                         else if (incoming_message.type() == Message_Type_DATA)
                         {
                             BOOST_LOG_SEV(log, trace) << "Processing data message";
-                            if (!connection_id)
+                            if (tac.adapter_config.is_v2_message_format)
                             {
                                 connection_id = 1;
-                                tac.adapter_config.is_v2_message_format = true;
                             }
                             tcp_connection::pointer connection = get_tcp_connection(tac, service_id, connection_id);
                             if (connection && connection->on_data_message)

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1425,12 +1425,6 @@ namespace aws { namespace iot { namespace securedtunneling {
             string service_id = message.serviceid();
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
-            //for backwards compatiblity with v2
-            if (tac.adapter_config.is_v2_message_format)
-            {
-                connection_id = 1;
-            }
-
             BOOST_LOG_SEV(log, trace) << "Forwarding message to tcp socket with connection id: " << connection_id;
             /**
              * v1 message format does not need to have service id field, so we don't need to do validation on this field.

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1070,9 +1070,10 @@ namespace aws { namespace iot { namespace securedtunneling {
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
             // backwards compatiblity with v2
-            if (tac.adapter_config.is_v2_message_format)
+            if (!connection_id)
             {
                 connection_id = 1;
+                tac.adapter_config.is_v2_message_format = true;
             }
             string service_id = message.serviceid();
             switch (message.type())
@@ -1324,9 +1325,10 @@ namespace aws { namespace iot { namespace securedtunneling {
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
             //for backwards compatibility with v2
-            if (tac.adapter_config.is_v2_message_format)
+            if (!connection_id)
             {
                 connection_id = 1;
+                tac.adapter_config.is_v2_message_format = true;
             }
             string service_id = message.serviceid();
             // v1 message format does not need to validate service id. Set to the one service id stored in memory.
@@ -1531,11 +1533,6 @@ namespace aws { namespace iot { namespace securedtunneling {
                         string service_id = incoming_message.serviceid();
                         uint32_t connection_id = static_cast<uint32_t>(incoming_message.connectionid());
                         // v1 message format does not need to validate service id. Set to the one service id stored in memory.
-                        if (!connection_id)
-                        {
-                            connection_id = 1;
-                            tac.adapter_config.is_v2_message_format = true;
-                        }
                         if (tac.adapter_config.is_v1_message_format)
                         {
                             service_id = tac.adapter_config.serviceId_to_endpoint_map.cbegin()->first;
@@ -1559,6 +1556,11 @@ namespace aws { namespace iot { namespace securedtunneling {
                         else if (incoming_message.type() == Message_Type_DATA)
                         {
                             BOOST_LOG_SEV(log, trace) << "Processing data message";
+                            if (!connection_id)
+                            {
+                                connection_id = 1;
+                                tac.adapter_config.is_v2_message_format = true;
+                            }
                             tcp_connection::pointer connection = get_tcp_connection(tac, service_id, connection_id);
                             if (connection && connection->on_data_message)
                             {

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1069,7 +1069,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             std::int32_t stream_id = static_cast<std::int32_t>(message.streamid());
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
-            // backwards compatiblity with v2
+            // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
             if (!connection_id)
             {
                 connection_id = 1;
@@ -1324,7 +1324,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             std::int32_t stream_id = static_cast<std::int32_t>(message.streamid());
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
-            //for backwards compatibility with v2
+            // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
             if (!connection_id)
             {
                 connection_id = 1;
@@ -1550,6 +1550,8 @@ namespace aws { namespace iot { namespace securedtunneling {
                         else if (incoming_message.type() == Message_Type_DATA)
                         {
                             BOOST_LOG_SEV(log, trace) << "Processing data message";
+
+                            // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
                             if (tac.adapter_config.is_v2_message_format)
                             {
                                 connection_id = 1;
@@ -1976,7 +1978,7 @@ namespace aws { namespace iot { namespace securedtunneling {
 
                         uint32_t new_connection_id = ++server->highest_connection_id;
 
-                        // backwards compatibility
+                        // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
                         if (tac.adapter_config.is_v2_message_format)
                         {
                             new_connection_id = 1;

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1070,10 +1070,9 @@ namespace aws { namespace iot { namespace securedtunneling {
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
             // backwards compatiblity with v2
-            if (!connection_id)
+            if (tac.adapter_config.is_v2_message_format)
             {
                 connection_id = 1;
-                tac.adapter_config.is_v2_message_format = true;
             }
             string service_id = message.serviceid();
             switch (message.type())
@@ -1325,10 +1324,9 @@ namespace aws { namespace iot { namespace securedtunneling {
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
             //for backwards compatibility with v2
-            if (!connection_id)
+            if (tac.adapter_config.is_v2_message_format)
             {
                 connection_id = 1;
-                tac.adapter_config.is_v2_message_format = true;
             }
             string service_id = message.serviceid();
             // v1 message format does not need to validate service id. Set to the one service id stored in memory.
@@ -1426,11 +1424,11 @@ namespace aws { namespace iot { namespace securedtunneling {
             uint32_t connection_id = static_cast<uint32_t>(message.connectionid());
 
             //for backwards compatiblity with v2
-            if (!connection_id)
+            if (tac.adapter_config.is_v2_message_format)
             {
                 connection_id = 1;
-                tac.adapter_config.is_v2_message_format = true;
             }
+
             BOOST_LOG_SEV(log, trace) << "Forwarding message to tcp socket with connection id: " << connection_id;
             /**
              * v1 message format does not need to have service id field, so we don't need to do validation on this field.
@@ -1533,6 +1531,11 @@ namespace aws { namespace iot { namespace securedtunneling {
                         string service_id = incoming_message.serviceid();
                         uint32_t connection_id = static_cast<uint32_t>(incoming_message.connectionid());
                         // v1 message format does not need to validate service id. Set to the one service id stored in memory.
+                        if (!connection_id)
+                        {
+                            connection_id = 1;
+                            tac.adapter_config.is_v2_message_format = true;
+                        }
                         if (tac.adapter_config.is_v1_message_format)
                         {
                             service_id = tac.adapter_config.serviceId_to_endpoint_map.cbegin()->first;


### PR DESCRIPTION
### Motivation
- Some CI tests using Device Client on the destination end have been failing
- Determined the cause to be missing a section of logic where the localproxy should set the connection id to 1 if it receives a message with no connection id (set to 0) sent from older versions of a Secure Tunneling client as is the case with Device Client.


### Modifications
#### Change summary
- Added the missing logic, added more descriptive comments.
- Added upload artifact github action to facilitate easier debugging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
