### PR TITLE
Update Dockerfile to use version 2 of amazonlinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# FROM amazonlinux:latest
+# FROM amazonlinux:2
 FROM amazonlinux:latest as builder
 ARG OPENSSL_CONFIG
 
@@ -89,7 +89,7 @@ WORKDIR /home/aws-iot-securetunneling-localproxy/
 
 ## Actual docker image
 
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 # Install openssl for libssl dependency.
 


### PR DESCRIPTION
tag "latest" is now pointing to Amazon Linux 2023, which breaks the build

### Motivation
Fix docker build script

### Modifications
#### Change summary
I changed docker tag from latest to exact version "2"

### Testing
 **Is your change tested? If not, please justify the reason.**  
Yes
 **Please list your testing steps and test results.** 
I ran successfully docker-buid.sh


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
