### PR TITLE
Add compatibility mode with Device Client 1.9 and Greengrass Secure Tunneling Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ and you can add ` -p <port_number>` to expose a port from the docker container. 
 Note: This step may be simpler to complete via a native software application manager.
 
 Ubuntu example:
-`sudo apt install zlibc`
+`sudo apt install zlib1g`
 
 Fedora example:
 `dnf install zlib`

--- a/src/LocalproxyConfig.h
+++ b/src/LocalproxyConfig.h
@@ -100,6 +100,7 @@ namespace aws {
                  * The end point will store either source listening or destination service depends on the mode of local proxy.
                  */
                 std::unordered_map<std::string, std::string>     serviceId_to_endpoint_map;
+
                 /**
                  * A flag to judge if v2 local proxy needs to fallback to communicate using v1 local proxy message format.
                  * v1 local proxy format fallback will be enabled when a tunnel is opened with no or 1 service id.

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -517,6 +517,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // if simultaneous connections are not enabled, then send a stream reset
             if (tac.adapter_config.is_v2_message_format)
             {
+                BOOST_LOG_SEV(log, info) << "simultaneous connections are not enabled, sending stream reset";
                 socket_connection->after_send_message = std::bind(&tcp_adapter_proxy::setup_tcp_socket, this, std::ref(tac), service_id);
                 tac.serviceId_to_control_message_handler_map[service_id] = std::bind(&tcp_adapter_proxy::ignore_message_and_stop, this, std::ref(tac), std::placeholders::_1);
                 async_send_stream_reset(tac, service_id, connection_id);
@@ -1073,6 +1074,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
             if (!connection_id)
             {
+                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
                 connection_id = 1;
                 tac.adapter_config.is_v2_message_format = true;
             }
@@ -1328,6 +1330,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
             if (!connection_id)
             {
+                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
                 connection_id = 1;
                 tac.adapter_config.is_v2_message_format = true;
             }
@@ -1431,6 +1434,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
             if (!connection_id)
             {
+                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
                 connection_id = 1;
                 tac.adapter_config.is_v2_message_format = true;
             }
@@ -1562,6 +1566,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                             // backward compatibility: set connection id to 1 if first received a message with no connection id (id value will be 0)
                             if (!connection_id)
                             {
+                                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
                                 connection_id = 1;
                                 tac.adapter_config.is_v2_message_format = true;
                             }
@@ -1990,6 +1995,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                         // backward compatibility: set connection id to 1 if simultaneous connections is not enabled
                         if (tac.adapter_config.is_v2_message_format)
                         {
+                            BOOST_LOG_SEV(log, info) << "Falling back to older protocol, setting new connection id to 1";
                             new_connection_id = 1;
                         }
                         BOOST_LOG_SEV(log, info) << "creating tcp connection id " << new_connection_id;

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -376,6 +376,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                 BOOST_LOG_SEV(this->log, trace) << "Post-reset TCP drain complete. Closing TCP socket for service id " << service_id << " connection id " << connection_id;
                 BOOST_LOG_SEV(this->log, info) << "Disconnected from: " << connection_to_reset->socket().remote_endpoint();
                 connection_to_reset->socket_.close();
+                delete_tcp_socket(tac, service_id, connection_id);
                 *tcp_write_buffer_drain_complete = true;
                 if (*web_socket_write_buffer_drain_complete)
                 {
@@ -2019,9 +2020,13 @@ namespace aws { namespace iot { namespace securedtunneling {
                         {
                             async_send_stream_start(tac, service_id, new_connection_id);
                         }
-                        else
+                        else if (!tac.adapter_config.is_v2_message_format)
                         {
                             async_send_connection_start(tac, service_id, new_connection_id);
+                        }
+                        else
+                        {
+                            BOOST_LOG_SEV(log, debug) << "Can not send stream start or connection start. Tried to use connection id: " << new_connection_id;
                         }
 
                         do_accept_tcp_connection(tac, retry_config, service_id, local_port, false);


### PR DESCRIPTION
### Motivation
- Improve logging and add compatibility mode for Device Client and Greengrass component users

tested end 2 end with DC 1.9 as the destination client


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
