### PR TITLE
PR to set SNI during boost lib websocket next_layer() SSL handshake process happen during launch of app tunneling.

### DIFF
--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -111,7 +111,7 @@ namespace aws { namespace iot { namespace securedtunneling {
         {
             std::ostringstream request_stream;
             request_stream << request;
-            std::string unfiltered_request_string = request_stream.str();
+            std::string unfiltered_request_string = request_stream.str(); 
             std::tuple<std::size_t, std::size_t> token_filter_range = get_access_token_range(unfiltered_request_string);
             return (boost::format("%1%***ACCESS_TOKEN_REMOVED***%2%") %
                 unfiltered_request_string.substr(0, std::get<0>(token_filter_range)) %
@@ -803,13 +803,13 @@ namespace aws { namespace iot { namespace securedtunneling {
         }
         tac.wss = std::make_shared<WebSocketStream>(tac.adapter_config, &log, tac.io_ctx);
         tac.wss->control_callback(std::bind(&tcp_adapter_proxy::handle_web_socket_control_message, this, std::ref(tac), std::placeholders::_1, std::placeholders::_2));
-
+        
         static std::string user_agent_string = (boost::format("localproxy %1% %2%-bit/boost-%3%.%4%.%5%/openssl-%6%.%7%.%8%/protobuf-%9%")
             % BOOST_PLATFORM % (sizeof(void*)*8)
             % (BOOST_VERSION / 100000) % ((BOOST_VERSION / 100) % 1000) % (BOOST_VERSION % 100)
             % (OPENSSL_VERSION_NUMBER >> 28) % ((OPENSSL_VERSION_NUMBER >> 20) & 0xF) % ((OPENSSL_VERSION_NUMBER >> 12) & 0xF)
             % google::protobuf::internal::VersionString(GOOGLE_PROTOBUF_VERSION) ).str();
-
+        
         //the actual work of this function starts here
         BOOST_LOG_SEV(log, info) << "Attempting to establish web socket connection with endpoint wss://" << tac.adapter_config.proxy_host << ":" << tac.adapter_config.proxy_port;
 
@@ -1910,7 +1910,7 @@ namespace aws { namespace iot { namespace securedtunneling {
         std::uint16_t port_to_connect = boost::lexical_cast<std::uint16_t>(src_port);
         BOOST_LOG_SEV(log, debug) << "Port to connect " << port_to_connect;
         server->resolver_.async_resolve(tac.bind_address_actual, src_port,
-            boost::asio::ip::resolver_base::passive,
+            boost::asio::ip::resolver_base::passive, 
             [=, &tac](boost::system::error_code const &ec, tcp::resolver::results_type results)
             {
                 if (ec)
@@ -2072,7 +2072,7 @@ namespace aws { namespace iot { namespace securedtunneling {
     void tcp_adapter_proxy::async_setup_dest_tcp_socket(tcp_adapter_context &tac, string const & service_id, uint32_t const & connection_id, bool is_first_connection)
     {
         BOOST_LOG_SEV(log, trace) << "Setup destination tcp socket for service id" << service_id;
-        std::shared_ptr<basic_retry_config> retry_config =
+        std::shared_ptr<basic_retry_config> retry_config = 
             std::make_shared<basic_retry_config>(tac.io_ctx,
                 GET_SETTING(settings, TCP_CONNECTION_RETRY_COUNT),
                 GET_SETTING(settings, TCP_CONNECTION_RETRY_DELAY_MS),

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -111,7 +111,7 @@ namespace aws { namespace iot { namespace securedtunneling {
         {
             std::ostringstream request_stream;
             request_stream << request;
-            std::string unfiltered_request_string = request_stream.str(); 
+            std::string unfiltered_request_string = request_stream.str();
             std::tuple<std::size_t, std::size_t> token_filter_range = get_access_token_range(unfiltered_request_string);
             return (boost::format("%1%***ACCESS_TOKEN_REMOVED***%2%") %
                 unfiltered_request_string.substr(0, std::get<0>(token_filter_range)) %
@@ -803,13 +803,13 @@ namespace aws { namespace iot { namespace securedtunneling {
         }
         tac.wss = std::make_shared<WebSocketStream>(tac.adapter_config, &log, tac.io_ctx);
         tac.wss->control_callback(std::bind(&tcp_adapter_proxy::handle_web_socket_control_message, this, std::ref(tac), std::placeholders::_1, std::placeholders::_2));
-        
+
         static std::string user_agent_string = (boost::format("localproxy %1% %2%-bit/boost-%3%.%4%.%5%/openssl-%6%.%7%.%8%/protobuf-%9%")
             % BOOST_PLATFORM % (sizeof(void*)*8)
             % (BOOST_VERSION / 100000) % ((BOOST_VERSION / 100) % 1000) % (BOOST_VERSION % 100)
             % (OPENSSL_VERSION_NUMBER >> 28) % ((OPENSSL_VERSION_NUMBER >> 20) & 0xF) % ((OPENSSL_VERSION_NUMBER >> 12) & 0xF)
             % google::protobuf::internal::VersionString(GOOGLE_PROTOBUF_VERSION) ).str();
-        
+
         //the actual work of this function starts here
         BOOST_LOG_SEV(log, info) << "Attempting to establish web socket connection with endpoint wss://" << tac.adapter_config.proxy_host << ":" << tac.adapter_config.proxy_port;
 
@@ -885,8 +885,8 @@ namespace aws { namespace iot { namespace securedtunneling {
                 {
                     BOOST_LOG_SEV(log, debug) << "SSL host verification is off";
                 }
-                //next ssl handshake
-                tac.wss->async_ssl_handshake(boost::asio::ssl::stream_base::client, [=, &tac](boost::system::error_code const &ec)
+                //next ssl handshake and providing host string
+                tac.wss->async_ssl_handshake(boost::asio::ssl::stream_base::client, tac.adapter_config.proxy_host.c_str(), [=, &tac](boost::system::error_code const &ec)
                 {
                     if (ec)
                     {
@@ -1910,7 +1910,7 @@ namespace aws { namespace iot { namespace securedtunneling {
         std::uint16_t port_to_connect = boost::lexical_cast<std::uint16_t>(src_port);
         BOOST_LOG_SEV(log, debug) << "Port to connect " << port_to_connect;
         server->resolver_.async_resolve(tac.bind_address_actual, src_port,
-            boost::asio::ip::resolver_base::passive, 
+            boost::asio::ip::resolver_base::passive,
             [=, &tac](boost::system::error_code const &ec, tcp::resolver::results_type results)
             {
                 if (ec)
@@ -2072,7 +2072,7 @@ namespace aws { namespace iot { namespace securedtunneling {
     void tcp_adapter_proxy::async_setup_dest_tcp_socket(tcp_adapter_context &tac, string const & service_id, uint32_t const & connection_id, bool is_first_connection)
     {
         BOOST_LOG_SEV(log, trace) << "Setup destination tcp socket for service id" << service_id;
-        std::shared_ptr<basic_retry_config> retry_config = 
+        std::shared_ptr<basic_retry_config> retry_config =
             std::make_shared<basic_retry_config>(tac.io_ctx,
                 GET_SETTING(settings, TCP_CONNECTION_RETRY_COUNT),
                 GET_SETTING(settings, TCP_CONNECTION_RETRY_DELAY_MS),

--- a/src/WebSocketStream.h
+++ b/src/WebSocketStream.h
@@ -150,7 +150,7 @@ namespace aws {
                  * @param handler the callback handler when the async operation is complete.
                  */
                 void
-                async_ssl_handshake(const ssl::stream_base::handshake_type &type, const BoostCallbackFunc &handler);
+                async_ssl_handshake(const ssl::stream_base::handshake_type &type, const std::string &host, const BoostCallbackFunc &handler);
 #endif
 
                 /**

--- a/src/WebSocketStream.h
+++ b/src/WebSocketStream.h
@@ -147,6 +147,7 @@ namespace aws {
                 /**
                  * Performs the SSL handshake between the localproxy and the proxy server asynchronously.
                  * @param type The handshake type
+                 * @param host the host subdoman and domain
                  * @param handler the callback handler when the async operation is complete.
                  */
                 void


### PR DESCRIPTION
This PR to set SNI during boost lib websocket next_layer() SSL handshake process happen during launch of app tunneling. 

### Motivation
- We have a use case for running AWS IoT secure tunnel within a Customer Managed VPN, along with a proxy service infrastructure to route multiple external services on a single domain. During the Customer Managed VPN setup, we noticed that the SSL handshake was failing when launching the local proxy. After a detailed investigation of the issue, we found that the code was not setting the Server Name Indication (SNI) during the initial SSL handshake call in the 'Client Hello' of the next_layer() SSL handshake code.
- This issue is linked to the Boost Beast WebSocket Secure (WSS) stream library code, which does not supply SNI by default during the next_layer() async_ssl_handshake() function. Therefore, following the example provided by the Boost library, it is suggested to use the SSL_set_tlsext_host_name function to set the SNI.
- This PR aims to resolve the SSL handshake issue and ensure that the code functions correctly in both non-VPN and VPN application tunnels.
- Issue number: AWS Case id: 13813696371


### Modifications
#### Change summary
Supplied host string From TcpAdapter which initiates async_ssl_hanshake
Extend WebSocketStream async_ssl_hanshake to take host string and use that to set SNI.
WebSocketSteam async_ssl_hanshake() code added with SSL_set_tlsext_host_name to set SNI with host string.

#### Revision diff summary
NA

### Testing
 **Is your change tested? Yes
 **Please list your testing steps and test results.** 
Login into CMVPN infra, 
Deploy the fixed code localproxy execuable 
open the tunnel. 
Check the connection status 
Connection status found connected at both sides
- CI test run result: NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.