### PR TITLE
fix zlib url for debian-ubuntu image

### DIFF
--- a/.github/docker-images/base-images/debian-ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/debian-ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt upgrade -y && \
 RUN mkdir /home/dependencies
 
 WORKDIR /home/dependencies
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://github.com/madler/zlib/archive/v1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
 	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \


### PR DESCRIPTION
### Motivation
- Unable to follow Debian image build step because of zlib url returning 404.

### Modifications
#### Change summary
- Changed zlib url to github release which is probably more stable than zlib.net one + updated to newest version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
