### PR TITLE
fix: update zlib download use github respository

### DIFF
--- a/.github/docker-images/base-images/amazonlinux/Dockerfile
+++ b/.github/docker-images/base-images/amazonlinux/Dockerfile
@@ -13,7 +13,7 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 RUN mkdir /home/dependencies
 
 WORKDIR /home/dependencies
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://github.com/madler/zlib/archive/v1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
 	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \

--- a/.github/docker-images/base-images/debian-ubuntu/Dockerfile
+++ b/.github/docker-images/base-images/debian-ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt upgrade -y && \
 RUN mkdir /home/dependencies
 
 WORKDIR /home/dependencies
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://github.com/madler/zlib/archive/v1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
 	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \

--- a/.github/docker-images/base-images/fedora/Dockerfile
+++ b/.github/docker-images/base-images/fedora/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf -y update \
 RUN mkdir /home/dependencies
 
 WORKDIR /home/dependencies
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://github.com/madler/zlib/archive/v1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
         tar xzvf /tmp/zlib-1.2.13.tar.gz && \
         cd zlib-1.2.13 && \
         ./configure && \

--- a/.github/docker-images/base-images/ubi8/Dockerfile
+++ b/.github/docker-images/base-images/ubi8/Dockerfile
@@ -9,7 +9,7 @@ RUN yum -y update \
 RUN mkdir /home/dependencies
 
 WORKDIR /home/dependencies
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://github.com/madler/zlib/archive/v1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
 	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yum check-update; yum upgrade -y && \
 RUN mkdir /home/dependencies
 WORKDIR /home/dependencies
 
-RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
+RUN wget https://github.com/madler/zlib/archive/v1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz && \
 	tar xzvf /tmp/zlib-1.2.13.tar.gz && \
 	cd zlib-1.2.13 && \
 	./configure && \


### PR DESCRIPTION
### Motivation
- Unable to download zlib status code 404


### Modifications
- Changing download url without breaking version compatibility

### Testing
- The change was tested and even generated an image for armv7 architectures, which can be found at. [aws-localproxy-32](https://hub.docker.com/r/joaopedrolucatto/localproxy-32)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
