### PR TITLE
update README for Mac Docker, fix info logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ if(BUILD_TESTS)
     # target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} OpenSSL::Crypto)
     ### uncomment above 2 lines and remove below 2 lines to link against OpenSSL shared libs
     target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${OpenSSL_STATIC_SSL_LIBRARY})
-    target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TARGET_NAME} ${OpenSSL_STATIC_CRYPTO_LIBRARY})
+    target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${OpenSSL_STATIC_CRYPTO_LIBRARY})
     target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${Boost_STATIC_LIBRARIES})
     target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${Protobuf_LITE_STATIC_LIBRARY})
     target_link_libraries(${AWS_TUNNEL_LOCAL_PROXY_TEST_NAME} ${CMAKE_DL_LIBS})

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The release images are minimum size images that include a pre-built binary with 
 
 `docker run --rm -it --network=host public.ecr.aws/aws-iot-securetunneling-localproxy/ubuntu-bin:amd64-latest --region us-east-1 -s 5555 -t <ACCESS_TOKEN>`
 
+On MacOS, --network=host does not work the way you expect it would. instead, do `docker run --rm -it -p 5555:5555 public.ecr.aws/aws-iot-securetunneling-localproxy/ubuntu-bin:amd64-latest --region us-east-1 -b 0.0.0.0 -s 5555 -t <ACCESS_TOKEN>`
+
 This will automatically pull down the latest docker image and run the localproxy without having to manually install it on your system.
 These images are tagged with the git commit and corresponding arch. Example: 33879dd7f1500f7b3e56e48ce8b002cd9b0f9e4e-amd64.
 You can cross-check the git commit sha with the commits in the local proxy repo to see if the binary contains changes added in a specific commit.

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1126,7 +1126,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // backward compatibility: set is_v2_message_format to true if receives no connection id
             if (!connection_id)
             {
-                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
+                BOOST_LOG_SEV(log, debug) << "reverting to v2 message format";
                 tac.adapter_config.is_v2_message_format = true;
             }
             string service_id = message.serviceid();
@@ -1374,7 +1374,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // backward compatibility: set is_v2_message_format to true if receives no connection id
             if (!connection_id)
             {
-                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
+                BOOST_LOG_SEV(log, debug) << "reverting to v2 message format";
                 tac.adapter_config.is_v2_message_format = true;
             }
             string service_id = message.serviceid();
@@ -1477,7 +1477,7 @@ namespace aws { namespace iot { namespace securedtunneling {
             // backward compatibility: set is_v2_message_format to true if receives no connection id
             if (!connection_id)
             {
-                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
+                BOOST_LOG_SEV(log, debug) << "reverting to v2 message format";
                 tac.adapter_config.is_v2_message_format = true;
             }
             /**
@@ -1608,7 +1608,7 @@ namespace aws { namespace iot { namespace securedtunneling {
                             // backward compatibility: set is_v2_message_format to true if receives no connection id
                             if (!connection_id)
                             {
-                                BOOST_LOG_SEV(log, info) << "reverting to v2 message format";
+                                BOOST_LOG_SEV(log, debug) << "reverting to v2 message format";
                                 tac.adapter_config.is_v2_message_format = true;
                             }
                             tcp_connection::pointer connection = get_tcp_connection(tac, service_id, connection_id);


### PR DESCRIPTION
### Modifications
- docker instructions did not mention that Docker desktop on Mac did not work as expected with `docker run --net host` argument

#### Revision diff summary
If there is more than one revision, please explain what has been changed since the last revision.

### Testing
 **Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.** 
- CI test run result: <link>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
