### PR TITLE
Updates upload-artifact version to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           cmake .. -DBUILD_TESTS=OFF -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1t/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl@1.1/1.1.1t/lib/
           make
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: localproxy-mac
           path: ${{ github.workspace }}/build/bin/localproxy
@@ -109,7 +109,7 @@ jobs:
           cmake .. -DBUILD_TESTS=OFF
           make
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: localproxy-ubuntu
           path: ${{ github.workspace }}/build/bin/localproxy
@@ -187,7 +187,7 @@ jobs:
           cmake -DBUILD_TESTS=OFF -DLINK_STATIC_OPENSSL=OFF -DBOOST_PKG_VERSION=1.84.0 -DWIN32_WINNT=0x0601 -DBoost_USE_STATIC_LIBS=ON -DCMAKE_PREFIX_PATH="C:\Boost;C:\Program Files (x86)\Catch2;C:\Program Files (x86)\protobuf;C:\Program Files\OpenSSL" -G "Visual Studio 16 2019" -A x64 ..\
           msbuild localproxy.vcxproj -p:Configuration=Release
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: localproxy-windows
           path: ${{ github.workspace }}\build\bin\Release\localproxy.exe


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.

Upload-artifact v3 is deprecated and is causing the CI workflow to fail


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
