### PR TITLE
Fix windows CI and update documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           Invoke-WebRequest "https://sourceforge.net/projects/boost/files/boost/1.87.0/boost_1_87_0.zip/download" -OutFile "boost_1_87_0.zip"
           Expand-Archive "boost_1_87_0.zip" -Force
-          cd .\boost_1_87_0\
+          cd .\boost_1_87_0\boost_1_87_0\
           .\bootstrap.bat
           .\b2 toolset=msvc-14.2 address-model=64 install define=_WIN32_WINNT=0x0601 define=BOOST_WINAPI_VERSION_WIN7 link=static
       - name: Install protobuf

--- a/windows-localproxy-build.md
+++ b/windows-localproxy-build.md
@@ -47,10 +47,11 @@
         * `nmake`
         * `nmake install` ( install protobuf inside C:\Program Files (x86)\ )
     * Download and install boost
-        * Download from https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz
-        * Extract boost_1_76_0.tar.gz
+        * Download from https://sourceforge.net/projects/boost/files/boost/1.87.0/boost_1_87_0.zip/download
+
+        * Extract boost_1_87_0.tar.gz
         * Use Visual Studio native tool command prompt
-        * `cd path/to/boost_1_76_0`
+        * `cd path/to/boost_1_87_0`
         * `bootstrap.bat`
         * `.\b2 toolset=msvc address-model={32 | 64} install define=BOOST_WINAPI_VERSION_WIN10` ( installs boost inside C:\)
             * Replace `BOOST_WINAPI_VERSION_WIN10` with the appropriate macro from [here](https://www.boost.org/doc/libs/develop/libs/winapi/doc/html/winapi/config.html)


### PR DESCRIPTION
### Motivation
- Please give a brief description for the background of this change.
- Issue number: https://github.com/aws-samples/aws-iot-securetunneling-localproxy/issues/178

Fix windows CI by updating boost path and update documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
