### PR TITLE
Add AF_UNIX support for destination (-d) mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,23 +748,26 @@ sets the mappings between port and service identifier. For example: SSH1=5555
 or 5555.
 
 - It follows format serviceId1=endpoint1, serviceId2=endpoint2, ...
-- Endpoint can be IP address:port, port, hostname:port, or a Unix domain socket path.
-- Unix domain socket paths are detected when the endpoint contains a '/' character
-  (e.g., /run/ssh-unix-local/socket, /tmp/app.sock, ./local.sock). Note: Unix domain
-  sockets are only supported on Unix/Linux/macOS platforms.
+- Endpoint can be IP address:port, port, hostname:port, or a Unix domain socket
+  path.
+- Unix domain socket paths are detected when the endpoint contains a '/'
+  character (e.g., /run/ssh-unix-local/socket, /tmp/app.sock, ./local.sock).
+  Note: Unix domain sockets are only supported on Unix/Linux/macOS platforms.
 - If only one port is needed to start local proxy, service ID is not needed. You
   can simply pass the port used, for example, 5555.
 - An item of the mapping SSH1=5555 means that local proxy will forward data
   received from the tunnel to TCP port 5555 for service ID SSH1.
-- An item of the mapping SSH1=/run/app.sock means that local proxy will forward data
-  received from the tunnel to the Unix domain socket at /run/app.sock for service ID SSH1.
+- An item of the mapping SSH1=/run/app.sock means that local proxy will forward
+  data received from the tunnel to the Unix domain socket at /run/app.sock for
+  service ID SSH1.
 - The value of service ID and how many service IDs are used needs to match with
   **services** in open tunnel call. For example:
   ```shell script
   aws iotsecuretunneling open-tunnel --destination-config thingName=foo,services=SSH1,SSH2
   ```
   Then to start local proxy in destination mode, need to use:
-  `-d SSH1=$port1,SSH2=$port2` or `-d SSH1=/path/to/socket1,SSH2=/path/to/socket2`
+  `-d SSH1=$port1,SSH2=$port2` or
+  `-d SSH1=/path/to/socket1,SSH2=/path/to/socket2`
 
 **-b/--local-bind-address [argvalue]** Specifies the local bind address (network
 interface) to use for listening for new connections when running the local proxy

--- a/README.md
+++ b/README.md
@@ -748,18 +748,22 @@ sets the mappings between port and service identifier. For example: SSH1=5555
 or 5555.
 
 - It follows format serviceId1=endpoint1, serviceId2=endpoint2, ...
-- Endpoint can be IP address:port , port or hostname:port.
+- Endpoint can be IP address:port, port, hostname:port, or a Unix domain socket path.
+- Unix domain socket paths are detected when the endpoint contains a '/' character
+  (e.g., /run/ssh-unix-local/socket, /tmp/app.sock, ./local.sock).
 - If only one port is needed to start local proxy, service ID is not needed. You
   can simply pass the port used, for example, 5555.
 - An item of the mapping SSH1=5555 means that local proxy will forward data
   received from the tunnel to TCP port 5555 for service ID SSH1.
+- An item of the mapping SSH1=/run/app.sock means that local proxy will forward data
+  received from the tunnel to the Unix domain socket at /run/app.sock for service ID SSH1.
 - The value of service ID and how many service IDs are used needs to match with
   **services** in open tunnel call. For example:
   ```shell script
   aws iotsecuretunneling open-tunnel --destination-config thingName=foo,services=SSH1,SSH2
   ```
   Then to start local proxy in destination mode, need to use:
-  `-d SSH1=$port1,SSH2=$port2`
+  `-d SSH1=$port1,SSH2=$port2` or `-d SSH1=/path/to/socket1,SSH2=/path/to/socket2`
 
 **-b/--local-bind-address [argvalue]** Specifies the local bind address (network
 interface) to use for listening for new connections when running the local proxy

--- a/README.md
+++ b/README.md
@@ -750,7 +750,8 @@ or 5555.
 - It follows format serviceId1=endpoint1, serviceId2=endpoint2, ...
 - Endpoint can be IP address:port, port, hostname:port, or a Unix domain socket path.
 - Unix domain socket paths are detected when the endpoint contains a '/' character
-  (e.g., /run/ssh-unix-local/socket, /tmp/app.sock, ./local.sock).
+  (e.g., /run/ssh-unix-local/socket, /tmp/app.sock, ./local.sock). Note: Unix domain
+  sockets are only supported on Unix/Linux/macOS platforms.
 - If only one port is needed to start local proxy, service ID is not needed. You
   can simply pass the port used, for example, 5555.
 - An item of the mapping SSH1=5555 means that local proxy will forward data

--- a/src/InputValidation.cpp
+++ b/src/InputValidation.cpp
@@ -223,6 +223,13 @@ namespace iot {
                     return;
                 }
 
+                // Check if it's a Unix socket path (contains '/')
+                // Unix socket paths: /run/socket, ./socket, /tmp/sock
+                if (endpoint.find('/') != std::string::npos) {
+                    validate_path(endpoint);
+                    return;
+                }
+
                 // It's host:port or just host - validate the address part
                 validate_bind_address(endpoint);
 

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -3167,17 +3167,17 @@ namespace iot {
 
             tcp_client::pointer client
                 = tac.serviceId_to_tcp_client_map[service_id];
-            
+
             // Create a Unix domain socket and connect
             boost::asio::local::stream_protocol::socket unix_socket(tac.io_ctx);
             boost::system::error_code connect_ec;
-            
+
             try {
                 unix_socket.connect(
                     boost::asio::local::stream_protocol::endpoint(socket_path),
                     connect_ec
                 );
-                
+
                 if (connect_ec) {
                     BOOST_LOG_SEV(log, error)
                         << (boost::format(
@@ -3198,15 +3198,16 @@ namespace iot {
                 } else {
                     BOOST_LOG_SEV(log, info)
                         << "Connected to Unix socket: " << socket_path;
-                    
+
                     // Transfer the Unix socket to the TCP connection
-                    // Get the native file descriptor and assign it to the TCP socket
+                    // Get the native file descriptor and assign it to the TCP
+                    // socket
                     int fd = unix_socket.release();
                     boost::system::error_code assign_ec;
                     client->connectionId_to_tcp_connection_map[connection_id]
                         ->socket()
                         .assign(boost::asio::ip::tcp::v4(), fd, assign_ec);
-                    
+
                     if (assign_ec) {
                         BOOST_LOG_SEV(log, error)
                             << "Failed to assign Unix socket to TCP socket: "

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -3153,7 +3153,7 @@ namespace iot {
         }
 
 #ifndef _WIN32
-        void tcp_adapter_proxy::async_connect_to_unix_socket(
+        void tcp_adapter_proxy::connect_and_setup_unix_socket(
             tcp_adapter_context &tac,
             std::shared_ptr<basic_retry_config> retry_config,
             const string &service_id,
@@ -3387,7 +3387,7 @@ namespace iot {
             if (endpoint.find('/') != std::string::npos) {
                 BOOST_LOG_SEV(log, debug)
                     << "Detected Unix domain socket path: " << endpoint;
-                async_connect_to_unix_socket(
+                connect_and_setup_unix_socket(
                     tac, retry_config, service_id, connection_id, endpoint
                 );
                 return;

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -1,11 +1,13 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #include "TcpAdapterProxy.h"
+#include "InputValidation.h"
 #include "ProxySettings.h"
 #include "WebProxyAdapter.h"
 #include "config/ConfigFile.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/ssl/host_name_verification.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/websocket.hpp>
@@ -20,6 +22,7 @@
 #include <functional>
 #include <openssl/opensslv.h>
 #include <set>
+#include <unistd.h> // for close() and unlink()
 
 namespace aws {
 namespace iot {
@@ -3147,6 +3150,89 @@ namespace iot {
             );
         }
 
+        void tcp_adapter_proxy::async_connect_to_unix_socket(
+            tcp_adapter_context &tac,
+            std::shared_ptr<basic_retry_config> retry_config,
+            const string &service_id,
+            const uint32_t &connection_id,
+            const std::string &socket_path
+        ) {
+            BOOST_LOG_SEV(log, trace)
+                << "Connecting to Unix domain socket: " << socket_path
+                << " for service id: " << service_id
+                << " connection id: " << connection_id;
+
+            tcp_client::pointer client
+                = tac.serviceId_to_tcp_client_map[service_id];
+            
+            // Create a Unix domain socket and connect
+            boost::asio::local::stream_protocol::socket unix_socket(tac.io_ctx);
+            boost::system::error_code connect_ec;
+            
+            try {
+                unix_socket.connect(
+                    boost::asio::local::stream_protocol::endpoint(socket_path),
+                    connect_ec
+                );
+                
+                if (connect_ec) {
+                    BOOST_LOG_SEV(log, error)
+                        << (boost::format(
+                                "Could not connect to Unix socket %1% -- %2%"
+                            )
+                            % socket_path % connect_ec.message())
+                               .str();
+                    basic_retry_execute(
+                        log, retry_config, [this, &tac, service_id]() {
+                            BOOST_LOG_SEV(log, trace)
+                                << "resetting stream for service id:"
+                                << service_id
+                                << ", then listen for stream start";
+                            async_send_stream_reset(tac, service_id);
+                            setup_tcp_socket(std::ref(tac), service_id);
+                        }
+                    );
+                } else {
+                    BOOST_LOG_SEV(log, info)
+                        << "Connected to Unix socket: " << socket_path;
+                    
+                    // Transfer the Unix socket to the TCP connection
+                    // Get the native file descriptor and assign it to the TCP socket
+                    int fd = unix_socket.release();
+                    boost::system::error_code assign_ec;
+                    client->connectionId_to_tcp_connection_map[connection_id]
+                        ->socket()
+                        .assign(boost::asio::ip::tcp::v4(), fd, assign_ec);
+                    
+                    if (assign_ec) {
+                        BOOST_LOG_SEV(log, error)
+                            << "Failed to assign Unix socket to TCP socket: "
+                            << assign_ec.message();
+                        ::close(fd);
+                        basic_retry_execute(
+                            log, retry_config, [this, &tac, service_id]() {
+                                async_send_stream_reset(tac, service_id);
+                                setup_tcp_socket(std::ref(tac), service_id);
+                            }
+                        );
+                    } else {
+                        async_setup_bidirectional_data_transfers(
+                            tac, service_id, connection_id
+                        );
+                    }
+                }
+            } catch (const std::exception &e) {
+                BOOST_LOG_SEV(log, error)
+                    << "Exception connecting to Unix socket: " << e.what();
+                basic_retry_execute(
+                    log, retry_config, [this, &tac, service_id]() {
+                        async_send_stream_reset(tac, service_id);
+                        setup_tcp_socket(std::ref(tac), service_id);
+                    }
+                );
+            }
+        }
+
         void tcp_adapter_proxy::async_resolve_destination_for_connect(
             tcp_adapter_context &tac,
             std::shared_ptr<basic_retry_config> retry_config,
@@ -3289,6 +3375,16 @@ namespace iot {
                         GET_SETTING(settings, WEB_SOCKET_WRITE_BUFFER_SIZE),
                         connection_id
                     );
+            }
+
+            // Check if endpoint is a Unix domain socket path (contains '/')
+            if (endpoint.find('/') != std::string::npos) {
+                BOOST_LOG_SEV(log, debug)
+                    << "Detected Unix domain socket path: " << endpoint;
+                async_connect_to_unix_socket(
+                    tac, retry_config, service_id, connection_id, endpoint
+                );
+                return;
             }
 
             if (tac.adapter_config.bind_address.has_value()) {

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -7,7 +7,10 @@
 #include "config/ConfigFile.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
+#ifndef _WIN32
 #include <boost/asio/local/stream_protocol.hpp>
+#include <unistd.h> // for close() and unlink()
+#endif
 #include <boost/asio/ssl/host_name_verification.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/websocket.hpp>
@@ -22,7 +25,6 @@
 #include <functional>
 #include <openssl/opensslv.h>
 #include <set>
-#include <unistd.h> // for close() and unlink()
 
 namespace aws {
 namespace iot {
@@ -3150,6 +3152,7 @@ namespace iot {
             );
         }
 
+#ifndef _WIN32
         void tcp_adapter_proxy::async_connect_to_unix_socket(
             tcp_adapter_context &tac,
             std::shared_ptr<basic_retry_config> retry_config,
@@ -3232,6 +3235,7 @@ namespace iot {
                 );
             }
         }
+#endif
 
         void tcp_adapter_proxy::async_resolve_destination_for_connect(
             tcp_adapter_context &tac,
@@ -3378,6 +3382,7 @@ namespace iot {
             }
 
             // Check if endpoint is a Unix domain socket path (contains '/')
+#ifndef _WIN32
             if (endpoint.find('/') != std::string::npos) {
                 BOOST_LOG_SEV(log, debug)
                     << "Detected Unix domain socket path: " << endpoint;
@@ -3386,6 +3391,17 @@ namespace iot {
                 );
                 return;
             }
+#else
+            // On Windows, reject Unix socket paths with a clear error
+            if (endpoint.find('/') != std::string::npos) {
+                BOOST_LOG_SEV(log, error)
+                    << "Unix domain sockets are not supported on Windows. "
+                    << "Path provided: " << endpoint;
+                throw std::runtime_error(
+                    "Unix domain sockets are not supported on Windows"
+                );
+            }
+#endif
 
             if (tac.adapter_config.bind_address.has_value()) {
                 BOOST_LOG_SEV(log, debug)

--- a/src/TcpAdapterProxy.h
+++ b/src/TcpAdapterProxy.h
@@ -453,7 +453,7 @@ namespace iot {
             );
 
 #ifndef _WIN32
-            void async_connect_to_unix_socket(
+            void connect_and_setup_unix_socket(
                 tcp_adapter_context &tac,
                 std::shared_ptr<basic_retry_config> retry_config,
                 const std::string &service_id,

--- a/src/TcpAdapterProxy.h
+++ b/src/TcpAdapterProxy.h
@@ -13,6 +13,7 @@
 #include "WebSocketStream.h"
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/ssl/host_name_verification.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/websocket.hpp>
@@ -447,6 +448,14 @@ namespace iot {
                 const uint32_t &connection_id,
                 const boost::system::error_code &ec,
                 tcp::resolver::results_type results
+            );
+
+            void async_connect_to_unix_socket(
+                tcp_adapter_context &tac,
+                std::shared_ptr<basic_retry_config> retry_config,
+                const std::string &service_id,
+                const uint32_t &connection_id,
+                const std::string &socket_path
             );
 
             bool process_incoming_websocket_buffer(

--- a/src/TcpAdapterProxy.h
+++ b/src/TcpAdapterProxy.h
@@ -13,7 +13,9 @@
 #include "WebSocketStream.h"
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#ifndef _WIN32
 #include <boost/asio/local/stream_protocol.hpp>
+#endif
 #include <boost/asio/ssl/host_name_verification.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/websocket.hpp>
@@ -450,6 +452,7 @@ namespace iot {
                 tcp::resolver::results_type results
             );
 
+#ifndef _WIN32
             void async_connect_to_unix_socket(
                 tcp_adapter_context &tac,
                 std::shared_ptr<basic_retry_config> retry_config,
@@ -457,6 +460,7 @@ namespace iot {
                 const uint32_t &connection_id,
                 const std::string &socket_path
             );
+#endif
 
             bool process_incoming_websocket_buffer(
                 tcp_adapter_context &tac,


### PR DESCRIPTION
This implementation adds AF_UNIX support to the destination mode so that the connectivity can be isolated to the host running the aws iot agent. Particularly useful in containers.

Issue number: https://github.com/aws-samples/aws-iot-securetunneling-localproxy/issues/177

### Testing

1) Implemented an echo server with below:
socat UNIX-LISTEN:/tmp/echo.sock,fork EXEC:/bin/cat Connected the local proxy with -d /tmp/echo.sock
Mapped this with another instance -s 3131.
Connected to it with telnet localhost 3131.
2) Mapped localproxy with -d /run/ssh-unix-local/socket to the running container's systemd generated ssh socket Started another instance of localproxy with -s 2222 Connected to it with ssh -p 2222 root@localhost

- CI test run result: NA

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
