### PR TITLE
Allow workflow to run for PR out of a branch but skip for forked source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ env:
 
 jobs:
   build-docker-image-ubuntu-amd64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -60,7 +62,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_UBUNTU }}:amd64-latest
           platforms: linux/amd64
   build-docker-image-ubuntu-arm64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -98,7 +102,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_UBUNTU }}:arm64-latest
           platforms: linux/arm64
   build-docker-image-ubuntu-armv7:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -136,7 +142,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_UBUNTU }}:armv7-latest
           platforms: linux/arm/v7
   build-docker-image-ubi8-amd64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -174,7 +182,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_UBI8 }}:amd64-latest
           platforms: linux/amd64
   build-docker-image-ubi8-arm64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -212,7 +222,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_UBI8 }}:arm64-latest
           platforms: linux/arm64
   build-docker-image-amazonlinux-amd64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -250,7 +262,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_AMAZONLINUX }}:amd64-latest
           platforms: linux/amd64
   build-docker-image-amazonlinux-arm64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -288,7 +302,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_AMAZONLINUX }}:arm64-latest
           platforms: linux/arm64
   build-docker-image-debian-amd64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -326,7 +342,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_DEBIAN }}:amd64-latest
           platforms: linux/amd64
   build-docker-image-debian-arm64:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -364,7 +382,9 @@ jobs:
             ${{ env.ECR_ACCOUNT_URL }}/${{ env.ECR_RELEASE_DEBIAN }}:arm64-latest
           platforms: linux/arm64
   build-image-manifest-ubuntu:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     needs:
       - build-docker-image-ubuntu-amd64
@@ -392,7 +412,9 @@ jobs:
           env.ECR_RELEASE_UBUNTU }}:armv7-latest
         shell: bash
   build-image-manifest-ubi8:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     needs:
       - build-docker-image-ubi8-amd64
@@ -415,7 +437,9 @@ jobs:
           env.ECR_RELEASE_UBI8 }}:amd64-latest ${{ env.ECR_ACCOUNT_URL }}/${{
           env.ECR_RELEASE_UBI8 }}:arm64-latest
   build-image-manifest-amazonlinux:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     needs:
       - build-docker-image-amazonlinux-amd64
@@ -438,7 +462,9 @@ jobs:
           env.ECR_RELEASE_AMAZONLINUX }}:amd64-latest ${{ env.ECR_ACCOUNT_URL
           }}/${{ env.ECR_RELEASE_AMAZONLINUX }}:arm64-latest
   build-image-manifest-debian:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     needs:
       - build-docker-image-debian-amd64

--- a/.github/workflows/uat-and-release.yml
+++ b/.github/workflows/uat-and-release.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     strategy:
       matrix:
         include:
@@ -129,7 +131,9 @@ jobs:
           path: build/bin/localproxy
 
   build-arm32:
-    if: github.repository == 'aws-samples/aws-iot-securetunneling-localproxy'
+    if:
+      github.repository == 'aws-samples/aws-iot-securetunneling-localproxy' &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-22.04
     env:
       BOOST_VERSION: "1.87.0"


### PR DESCRIPTION
### Motivation

- The pull request raised from external customers trigger all the workflows but few of them such as UAT and Release build cannot run with proper authentication and need to be skipped for PR from forked repos.

### Modifications

#### Change summary

Please describe what changes are included in this pull request.

- Add a skip statement based of the the pull request is originating from a forked repo targeting main

#### Revision diff summary

If there is more than one revision, please explain what has been changed since
the last revision.

### Testing

**Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.**

Tested with the PR from a branch https://github.com/aws-samples/aws-iot-securetunneling-localproxy/pull/214


Note: As I updated a copy of the content with the same branch name the tests on this PR were also triggered, which was not expected. 

- CI test run result: <link>

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
