### PR TITLE
Fix and Hardnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# AGENTS.md
+
+Guidance for agents (and humans) making commits to
+**aws-iot-securetunneling-localproxy**. This repo is a C++14 / CMake project
+(not a Brazil package); it uses Boost.Asio/Beast, protobuf and OpenSSL, and a
+Nix flake provides the formatter. See `CONTRIBUTING.md` for the project's
+overall contribution policy (issues, PRs, CLA).
+
+---
+
+## TL;DR commit checklist
+
+Before every commit:
+
+1. Make one focused, logical change.
+2. `nix fmt` — format the tree (must end clean / idempotent).
+3. Build and run the unit tests (see below); ensure they pass.
+4. Stage only the files for this change; write a clear message (see below).
+5. Never commit to `main`; never force-push a shared branch without
+   coordinating.
+
+---
+
+## Branching
+
+- Work on a feature branch named `dev/<short-kebab-name>` (e.g.
+  `dev/security-audit-findings`).
+- Per `CONTRIBUTING.md`, work against the latest `main` and keep a change
+  focused on one thing — don't reformat unrelated code.
+- History may be reworded/rebased **only while the branch has not been pushed**.
+  Once shared, prefer new commits; rewriting then requires a coordinated
+  force-push.
+
+## One change per commit
+
+- Each commit should be a single, self-contained change (one fix / one feature).
+  Don't mix unrelated changes.
+- Keep the **tests** and **docs** for a change in the same commit as the change
+  (e.g. URL-parsing tests live with the URL-parsing fix).
+- Keep **formatting** in the same commit as the code it applies to. Normally
+  this is automatic: just run `nix fmt` _before_ committing. (Redistributing
+  formatting across already-made commits is only needed if it was applied after
+  the fact — not part of the normal flow.)
+
+## Commit message style
+
+Match the existing history: a short, imperative, capitalized subject with **no
+trailing period**, under ~70 characters.
+
+```
+<Imperative subject, e.g. "Fix double callback and buffer leak in WebProxyAdapter">
+
+<One-line statement of the problem / context.>
+
+- Short bullet per distinct point: the reason (why) and the idea (how).
+
+Tests: <one line, if tests were added/changed>
+Docs:  <one line, if docs were added/changed>
+```
+
+- Subject says _what_ changes; body says _why_ and _the idea_. Keep it terse.
+- Use bullets for multiple points; a single `Fix:` line is fine for simple
+  changes.
+- Reference symbols/files in `code font` where it aids clarity.
+
+Examples from history:
+
+- `Add AF_UNIX support for destination (-d) mode`
+- `Fix editor-config errors`
+
+## Build & test
+
+The project builds with CMake + make (see `README.md` for full dependency setup:
+Boost 1.87, Protobuf 3.17.x, zlib, OpenSSL, Catch2). From the repo root:
+
+```bash
+mkdir -p build && cd build
+cmake ../ -DBUILD_TESTS=ON        # add -DLINK_STATIC_OPENSSL=OFF for dynamic OpenSSL
+make -j"$(nproc)"
+```
+
+- The proxy binary is produced at `build/bin/localproxy`.
+- With `-DBUILD_TESTS=ON`, the Catch2 test binary is `build/bin/localproxytest`;
+  run it to execute the unit suite. Ensure all tests pass before committing.
+- Build directories matching `*build*/` are git-ignored.
+
+Relevant CMake options (top of `CMakeLists.txt`):
+
+- `BUILD_TESTS` (default OFF) — build the Catch2 unit tests under `test/`.
+- `LINK_STATIC_OPENSSL` (default ON) — statically link OpenSSL.
+- `GIT_VERSION` (default ON) — derive the version from git history.
+- `DISABLE_SSL_HOST_VERIFY_OPT` (default OFF) — production builds may drop the
+  `--no-ssl-host-verify` option.
+
+## Formatting & config
+
+- Format with `nix fmt` before committing (treefmt via `flake.nix`: clang-format
+  for C/C++ using `.clang-format`, prettier for Markdown using
+  `prettierrc.yml`). A clean tree after `nix fmt` (no diff) is required; don't
+  hand-format against the style.
+- If `nix` is not found, install Lix:
+  ```bash
+  curl -sSf -L https://install.lix.systems/lix | sh -s -- install
+  ```
+- The repo also ships `.clang-tidy` and `.cmake-format.json`; honor them if you
+  run those tools. There are no committed wrapper scripts — run any such tools
+  directly.
+
+## Code conventions / gotchas
+
+- C++14. Preserve existing comments and `BOOST_LOG_SEV` logging statements.
+- Prefer RAII (`shared_ptr`/`unique_ptr`, `lock_guard`) over raw `new`/`delete`
+  and manual unlocking.
+- **Boost.Asio handler lifetime:** async completion handlers must outlive the
+  call that posts them. For self-re-arming handlers use a
+  `shared_ptr<std::function>` captured by value and break the resulting
+  self-cycle on terminal paths; or capture a `weak_ptr` when another owner (e.g.
+  a retry timer) already holds a strong ref for the duration of the call. Note
+  that leak detectors generally cannot see `shared_ptr` reference cycles —
+  reason about those by hand.
+- Validate external input: range-check ports to `[0, 65535]`, handle
+  `std::out_of_range` from `stoi`, and reject malformed URLs.
+- Security: the proxy negotiates TLS 1.2+ only (SSLv2/3 and TLS 1.0/1.1 are
+  disabled in the SSL context).
+
+## Do / don't
+
+- DO keep commits small, buildable, and individually reviewable.
+- DO run `nix fmt`, build, and tests before committing.
+- DON'T weaken or delete tests to make a build pass — fix the code.
+- DON'T commit to `main` or force-push shared branches without coordination.
+- DON'T strip comments/logging or expand a commit's scope beyond its stated fix.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ container.
   - Boost 1.87
   - Protobuf 3.17.x
   - zlib 1.12.13+
-  - OpenSSL 1.0+ OR OpenSSL 3
+  - OpenSSL 1.0.1+ OR OpenSSL 3 (must support TLS 1.2)
   - Catch2 test framework
 - Stage a dependency build directory and change directory into it:
   - `mkdir dependencies`
@@ -592,6 +592,13 @@ properly, Please refer to
 
 ### Security Considerations
 
+#### TLS protocol versions
+
+The local proxy negotiates **TLS 1.2 or higher** when connecting to the AWS IoT
+service and to a TLS web proxy. The obsolete SSLv2, SSLv3, TLS 1.0 and TLS 1.1
+protocols are explicitly disabled, so the OpenSSL build used must support TLS
+1.2 (OpenSSL 1.0.1 or later, or OpenSSL 3).
+
 #### Certificate setup
 
 A likely issue with the local proxy running on Windows or macOS systems is the
@@ -687,7 +694,9 @@ connect or as the listening address. If localhost resolves to '::1' then IPv6
 will be used.
 
 **Note:** Specifying any argument that normally accepts _address:port_ will not
-work correctly if _address_ is specified using an IPv6 address.
+work correctly if _address_ is specified using an IPv6 address. The one
+exception is the web proxy URL (for example the `HTTPS_PROXY` environment
+variable), which accepts a bracketed IPv6 literal such as `http://[::1]:8080`.
 
 **Note:** Systems that support both IPv4 and IPv6 may cause connectivity
 confusion if explicit address/port combinations are not used with the local

--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -27,10 +27,13 @@ Myho
 NASM
 nmake
 pkgs
+RAII
 Rjnmc
 rootca
 shfmt
 sslv
+stoi
+treefmt
 Uhdrl
 VQZH
 Vugzrm

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -2098,8 +2098,11 @@ namespace iot {
                     BOOST_LOG_SEV(log, warning)
                         << "Starting new stream for service id: " << service_id;
                     tac.serviceId_to_streamId_map[service_id] = stream_id;
-                    tac.serviceId_to_tcp_client_map[service_id]
-                        ->on_receive_stream_start();
+                    if (tac.serviceId_to_tcp_client_map[service_id]
+                            ->on_receive_stream_start) {
+                        tac.serviceId_to_tcp_client_map[service_id]
+                            ->on_receive_stream_start();
+                    }
                 } else if (tac.serviceId_to_streamId_map.at(service_id)
                            != message.streamid()) {
                     BOOST_LOG_SEV(log, warning)
@@ -2857,9 +2860,19 @@ namespace iot {
                 }
             }
 
-            // We are not currently writing, so send this immediately
-            data_message message_to_send
-                = tac.web_socket_outgoing_message_queue.front();
+            // We are not currently writing, so send this immediately.
+            // Read the front element under the queue mutex (push/pop are also
+            // synchronized on this mutex) and copy it out before releasing.
+            data_message message_to_send;
+            {
+                const std::lock_guard<std::mutex> lock(
+                    tac.web_socket_outgoing_message_queue_mutex
+                );
+                if (tac.web_socket_outgoing_message_queue.empty()) {
+                    return;
+                }
+                message_to_send = tac.web_socket_outgoing_message_queue.front();
+            }
 
             tac.wss->async_write(
                 message_to_send.first->data(),
@@ -2885,16 +2898,22 @@ namespace iot {
                         capture_after_send_message();
                     }
 
-                    const std::lock_guard<std::mutex> lock(
-                        tac.web_socket_outgoing_message_queue_mutex
-                    );
-                    tac.web_socket_outgoing_message_queue.pop();
-                    if (tac.web_socket_outgoing_message_queue.empty()) {
-                        BOOST_LOG_SEV(log, trace)
-                            << "web_socket_outgoing_message_queue is empty, no "
-                               "more messages to send.";
-                        return;
+                    {
+                        const std::lock_guard<std::mutex> lock(
+                            tac.web_socket_outgoing_message_queue_mutex
+                        );
+                        tac.web_socket_outgoing_message_queue.pop();
+                        if (tac.web_socket_outgoing_message_queue.empty()) {
+                            BOOST_LOG_SEV(log, trace)
+                                << "web_socket_outgoing_message_queue is "
+                                   "empty, no more messages to send.";
+                            return;
+                        }
                     }
+                    // Release the queue mutex before draining the next message:
+                    // async_send_message_to_web_socket re-acquires this same
+                    // (non-recursive) mutex to read front(), so holding it here
+                    // would self-deadlock the io_context thread.
                     async_send_message_to_web_socket(
                         tac, nullptr, service_id, connection_id
                     );

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -2546,72 +2546,6 @@ namespace iot {
                         .str()
                 );
             }
-            static std::function<
-                void(const boost::system::error_code &, size_t)>
-                write_done;
-            write_done = [&, service_id, connection_id](
-                             const boost::system::error_code &ec,
-                             size_t bytes_written
-                         ) {
-                BOOST_LOG_SEV(log, trace)
-                    << "write done service id " << service_id
-                    << ", connection id: " << connection_id;
-                tcp_connection::pointer socket_write_connection
-                    = get_tcp_connection(tac, service_id, connection_id);
-                if (!socket_write_connection) {
-                    return;
-                }
-                socket_write_connection->is_tcp_socket_writing_ = false;
-                if (ec) {
-                    if (socket_write_connection->on_tcp_error) {
-                        socket_write_connection->on_tcp_error(ec);
-                        socket_write_connection->on_tcp_error = nullptr;
-                    } else {
-                        tcp_socket_error(tac, ec, service_id, connection_id);
-                    }
-                } else {
-                    BOOST_LOG_SEV(log, trace)
-                        << "Wrote " << bytes_written
-                        << " bytes to tcp socket with service id: "
-                        << service_id << ", connection_id: " << connection_id;
-                    bool had_space_before = tcp_has_enough_write_buffer_space(
-                        socket_write_connection
-                    );
-                    socket_write_connection->tcp_write_buffer_.consume(
-                        bytes_written
-                    );
-                    bool has_space_after = tcp_has_enough_write_buffer_space(
-                        socket_write_connection
-                    );
-                    if (!had_space_before && has_space_after) {
-                        BOOST_LOG_SEV(log, debug)
-                            << "Just cleared enough buffer space in tcp write "
-                               "buffer. Re-starting async web socket read loop";
-                        async_web_socket_read_loop(tac);
-                    }
-                    if (socket_write_connection->tcp_write_buffer_.size() > 0) {
-                        socket_write_connection->is_tcp_socket_writing_ = true;
-                        BOOST_LOG_SEV(log, debug) << "Write to tcp socket";
-                        socket_write_connection->socket_.async_write_some(
-                            socket_write_connection->tcp_write_buffer_.data(),
-                            write_done
-                        );
-                    } else {
-                        if (socket_write_connection
-                                ->on_tcp_write_buffer_drain_complete) {
-                            invoke_and_clear_handler(
-                                socket_write_connection
-                                    ->on_tcp_write_buffer_drain_complete
-                            );
-                        }
-                        BOOST_LOG_SEV(log, trace)
-                            << "TCP write buffer drain complete";
-                    }
-                    BOOST_LOG_SEV(log, trace)
-                        << "Done writing for: " << service_id
-                        << ", connection id: " << connection_id;
-                }
-            };
             if (connection->is_tcp_socket_writing_) {
                 BOOST_LOG_SEV(log, debug) << "TCP write buffer drain cannot be "
                                              "started while already writing";
@@ -2620,9 +2554,106 @@ namespace iot {
                     connection->on_tcp_write_buffer_drain_complete
                 );
             } else {
+                // Self-owning handler via shared_ptr: constructed only when an
+                // async write is actually initiated. The lambda captures the
+                // shared_ptr by value so the handler outlives
+                // async_tcp_write_buffer_drain's stack frame. The
+                // self-reference cycle (shared_ptr -> std::function -> captures
+                // shared_ptr) is broken on every terminal path by clearing the
+                // stored std::function, which drops the captured shared_ptr
+                // copy.
+                auto write_done = std::make_shared<std::function<
+                    void(const boost::system::error_code &, size_t)>>();
+                *write_done = [this,
+                               &tac,
+                               service_id,
+                               connection_id,
+                               write_done](
+                                  const boost::system::error_code &ec,
+                                  size_t bytes_written
+                              ) {
+                    BOOST_LOG_SEV(log, trace)
+                        << "write done service id " << service_id
+                        << ", connection id: " << connection_id;
+                    tcp_connection::pointer socket_write_connection
+                        = get_tcp_connection(tac, service_id, connection_id);
+                    if (!socket_write_connection) {
+                        // Terminal path: break self-reference cycle
+                        *write_done = nullptr;
+                        return;
+                    }
+                    socket_write_connection->is_tcp_socket_writing_ = false;
+                    if (ec) {
+                        if (socket_write_connection->on_tcp_error) {
+                            socket_write_connection->on_tcp_error(ec);
+                            socket_write_connection->on_tcp_error = nullptr;
+                        } else {
+                            tcp_socket_error(
+                                tac, ec, service_id, connection_id
+                            );
+                        }
+                        // Terminal path: break self-reference cycle
+                        *write_done = nullptr;
+                    } else {
+                        BOOST_LOG_SEV(log, trace)
+                            << "Wrote " << bytes_written
+                            << " bytes to tcp socket with service id: "
+                            << service_id
+                            << ", connection_id: " << connection_id;
+                        bool had_space_before
+                            = tcp_has_enough_write_buffer_space(
+                                socket_write_connection
+                            );
+                        socket_write_connection->tcp_write_buffer_.consume(
+                            bytes_written
+                        );
+                        bool has_space_after
+                            = tcp_has_enough_write_buffer_space(
+                                socket_write_connection
+                            );
+                        if (!had_space_before && has_space_after) {
+                            BOOST_LOG_SEV(log, debug)
+                                << "Just cleared enough buffer space in tcp "
+                                   "write "
+                                   "buffer. Re-starting async web socket read "
+                                   "loop";
+                            async_web_socket_read_loop(tac);
+                        }
+                        bool rearmed = false;
+                        if (socket_write_connection->tcp_write_buffer_.size()
+                            > 0) {
+                            socket_write_connection->is_tcp_socket_writing_
+                                = true;
+                            BOOST_LOG_SEV(log, debug) << "Write to tcp socket";
+                            socket_write_connection->socket_.async_write_some(
+                                socket_write_connection->tcp_write_buffer_
+                                    .data(),
+                                *write_done
+                            );
+                            rearmed = true;
+                        } else {
+                            if (socket_write_connection
+                                    ->on_tcp_write_buffer_drain_complete) {
+                                invoke_and_clear_handler(
+                                    socket_write_connection
+                                        ->on_tcp_write_buffer_drain_complete
+                                );
+                            }
+                            BOOST_LOG_SEV(log, trace)
+                                << "TCP write buffer drain complete";
+                        }
+                        BOOST_LOG_SEV(log, trace)
+                            << "Done writing for: " << service_id
+                            << ", connection id: " << connection_id;
+                        if (!rearmed) {
+                            // Terminal path: break self-reference cycle
+                            *write_done = nullptr;
+                        }
+                    }
+                };
                 connection->is_tcp_socket_writing_ = true;
                 connection->socket_.async_write_some(
-                    connection->tcp_write_buffer_.data(), write_done
+                    connection->tcp_write_buffer_.data(), *write_done
                 );
             }
         }

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -260,13 +260,17 @@ namespace iot {
                         GET_SETTING(settings, TCP_CONNECTION_RETRY_DELAY_MS),
                         nullptr
                     );
-                retry_config->operation = std::bind(
-                    &tcp_adapter_proxy::async_setup_source_tcp_socket_retry,
-                    this,
-                    std::ref(tac),
-                    retry_config,
-                    service_id
-                );
+                // Break shared_ptr self-cycle by capturing weak_ptr
+                std::weak_ptr<basic_retry_config> weak_retry_config
+                    = retry_config;
+                retry_config->operation
+                    = [this, &tac, weak_retry_config, service_id]() {
+                          if (auto rc = weak_retry_config.lock()) {
+                              async_setup_source_tcp_socket_retry(
+                                  tac, rc, service_id
+                              );
+                          }
+                      };
                 async_setup_source_tcp_socket_retry(
                     tac, retry_config, service_id
                 );
@@ -3046,15 +3050,20 @@ namespace iot {
             std::uint16_t local_port,
             bool is_first_connection
         ) {
-            retry_config->operation = std::bind(
-                &tcp_adapter_proxy::do_accept_tcp_connection,
-                this,
-                std::ref(tac),
-                retry_config,
-                service_id,
-                local_port,
-                is_first_connection
-            );
+            // Break shared_ptr self-cycle by capturing weak_ptr
+            std::weak_ptr<basic_retry_config> weak_retry_config = retry_config;
+            retry_config->operation = [this,
+                                       &tac,
+                                       weak_retry_config,
+                                       service_id,
+                                       local_port,
+                                       is_first_connection]() {
+                if (auto rc = weak_retry_config.lock()) {
+                    do_accept_tcp_connection(
+                        tac, rc, service_id, local_port, is_first_connection
+                    );
+                }
+            };
             tcp_server::pointer server
                 = tac.serviceId_to_tcp_server_map[service_id];
 
@@ -3355,15 +3364,20 @@ namespace iot {
                     GET_SETTING(settings, TCP_CONNECTION_RETRY_DELAY_MS),
                     nullptr
                 );
-            retry_config->operation = std::bind(
-                &tcp_adapter_proxy::async_setup_dest_tcp_socket_retry,
-                this,
-                std::ref(tac),
-                retry_config,
-                service_id,
-                connection_id,
-                is_first_connection
-            );
+            // Break shared_ptr self-cycle by capturing weak_ptr
+            std::weak_ptr<basic_retry_config> weak_retry_config = retry_config;
+            retry_config->operation = [this,
+                                       &tac,
+                                       weak_retry_config,
+                                       service_id,
+                                       connection_id,
+                                       is_first_connection]() {
+                if (auto rc = weak_retry_config.lock()) {
+                    async_setup_dest_tcp_socket_retry(
+                        tac, rc, service_id, connection_id, is_first_connection
+                    );
+                }
+            };
             async_setup_dest_tcp_socket_retry(
                 tac,
                 retry_config,

--- a/src/Url.cpp
+++ b/src/Url.cpp
@@ -75,9 +75,24 @@ void aws::iot::securedtunneling::url::parse(const string &url_s) {
     const size_t host_i = is_authN_included
         ? authentication_end_i + 1
         : protocol_end_i + protocol_end.size();
-    const size_t port_i = url_s.find(':', host_i);
-
-    host = get_substring(url_s, host_i, port_i);
+    size_t port_i;
+    if (host_i < url_s.length() && url_s[host_i] == '[') {
+        // IPv6 literal enclosed in brackets, e.g. [::1]:8080
+        const size_t bracket_end = url_s.find(']', host_i);
+        if (bracket_end == string::npos) {
+            throw invalid_argument(
+                "Invalid IPv6 address in URL: missing closing ']'"
+            );
+        }
+        host = get_substring(url_s, host_i + 1, bracket_end);
+        port_i = (bracket_end + 1 < url_s.length()
+                  && url_s[bracket_end + 1] == ':')
+            ? bracket_end + 1
+            : string::npos;
+    } else {
+        port_i = url_s.find(':', host_i);
+        host = get_substring(url_s, host_i, port_i);
+    }
 
     if (host.empty()) {
         throw invalid_argument("Missing HTTP host address");
@@ -86,7 +101,11 @@ void aws::iot::securedtunneling::url::parse(const string &url_s) {
     if (port_i != string::npos) {
         const string port_s = get_substring(url_s, port_i + 1, url_s.length());
         try {
-            port = static_cast<uint16_t>(stoi(port_s));
+            const int port_num = stoi(port_s);
+            if (port_num < 0 || port_num > 65535) {
+                throw out_of_range("Port number out of range [0, 65535]");
+            }
+            port = static_cast<uint16_t>(port_num);
         } catch (exception &e) {
             BOOST_LOG_TRIVIAL(fatal) << "Failed to parse the port";
             BOOST_LOG_TRIVIAL(fatal) << e.what();
@@ -106,6 +125,12 @@ string aws::iot::securedtunneling::url::url_decode(const string &url_s) {
                     int value = 0;
                     std::istringstream is(url_s.substr(i + 1, 2));
                     if (is >> std::hex >> value) {
+                        if (value == 0) {
+                            throw invalid_argument(
+                                "Invalid URL: encoded null byte (%00) is not "
+                                "allowed"
+                            );
+                        }
                         out += static_cast<char>(value);
                         i += 2;
                     } else {

--- a/src/WebProxyAdapter.cpp
+++ b/src/WebProxyAdapter.cpp
@@ -7,6 +7,8 @@
 #include <boost/beast/http.hpp>
 #include <boost/log/sources/severity_feature.hpp>
 #include <boost/log/sources/severity_logger.hpp>
+#include <memory>
+#include <vector>
 
 namespace base64 = boost::beast::detail::base64;
 using boost::log::trivial::debug;
@@ -173,9 +175,9 @@ namespace iot {
         void WebProxyAdapter::on_http_connect_write() {
             BOOST_LOG_SEV(*log, trace)
                 << "Waiting for HTTP CONNECT response from the Web proxy";
-            char *response_buffer = new char[BUFFER_SIZE_IN_BYTES];
-            read_buffer
-                = boost::asio::buffer(response_buffer, BUFFER_SIZE_IN_BYTES);
+            auto response_buffer
+                = std::make_shared<std::vector<char>>(BUFFER_SIZE_IN_BYTES);
+            read_buffer = boost::asio::buffer(*response_buffer);
             auto on_read = [this, response_buffer](
                                const error_code &ec,
                                std::size_t bytes_transferred
@@ -189,6 +191,7 @@ namespace iot {
                             % ec.message())
                                .str();
                     (*on_tcp_tunnel)(WebProxyAdapterErrc::ServerError);
+                    return;
                 }
                 BOOST_LOG_SEV(*log, trace)
                     << "Parsing the HTTPS response from the Web proxy";
@@ -243,7 +246,6 @@ namespace iot {
                     (*on_tcp_tunnel)(WebProxyAdapterErrc::OtherHttpError);
                     break;
                 }
-                delete[] response_buffer;
             };
             // Initially I tried to use boost::beast::http::async_read, but for
             // some reason the beast implementation of that method disrupted the

--- a/src/WebSocketStream.cpp
+++ b/src/WebSocketStream.cpp
@@ -314,6 +314,18 @@ namespace iot {
             , socket { io_context }
             , log(log) {
             boost::system::error_code ec;
+            // Restrict to modern TLS: disable SSLv2/SSLv3/TLSv1.0/TLSv1.1
+            ssl_context.set_options(
+                ssl::context::default_workarounds | ssl::context::no_sslv2
+                    | ssl::context::no_sslv3 | ssl::context::no_tlsv1
+                    | ssl::context::no_tlsv1_1,
+                ec
+            );
+            if (ec) {
+                BOOST_LOG_SEV(*log, warning)
+                    << "Could not restrict TLS protocol versions: "
+                    << ec.message();
+            }
             ssl_context.set_default_verify_paths(ec);
             if (ec) {
                 BOOST_LOG_SEV(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,9 +69,12 @@ tuple<string, uint16_t> get_host_and_port(
             const string port = endpoint.substr(
                 position + 1, endpoint.length() - (position + 1)
             );
-            const auto portnum = static_cast<uint16_t>(stoi(port, &position));
+            const int portnum_int = stoi(port, &position);
             if (port.length() == 0 || position != port.length())
                 throw std::invalid_argument("");
+            if (portnum_int < 0 || portnum_int > 65535)
+                throw std::out_of_range("");
+            const auto portnum = static_cast<uint16_t>(portnum_int);
             return std::make_tuple(host, portnum);
         } else {
             if (position == endpoint.length() - 1)
@@ -79,6 +82,10 @@ tuple<string, uint16_t> get_host_and_port(
             return std::make_tuple(endpoint, default_port);
         }
     } catch (std::invalid_argument &) {
+        throw std::invalid_argument(
+            (boost::format("Invalid endpoint specified: %1%") % endpoint).str()
+        );
+    } catch (const std::out_of_range &) {
         throw std::invalid_argument(
             (boost::format("Invalid endpoint specified: %1%") % endpoint).str()
         );

--- a/test/Url.cpp
+++ b/test/Url.cpp
@@ -42,6 +42,27 @@ namespace iot {
                 }
             }
 
+            TEST_CASE("Unit tests for Url.h-IPv6-cases") {
+                cout << "Unit test IPv6 cases for Url.h" << endl;
+                {
+                    aws::iot::securedtunneling::url url { "http://[::1]:8080" };
+                    REQUIRE(url.host == "::1");
+                    REQUIRE(url.port == 8080);
+                }
+                {
+                    aws::iot::securedtunneling::url url {
+                        "https://[2001:db8::1]:443"
+                    };
+                    REQUIRE(url.host == "2001:db8::1");
+                    REQUIRE(url.port == 443);
+                }
+                {
+                    // bracketed IPv6 literal with no explicit port
+                    aws::iot::securedtunneling::url url { "http://[fe80::1]" };
+                    REQUIRE(url.host == "fe80::1");
+                }
+            }
+
             TEST_CASE("Unit tests for Url-invalid-urls") {
                 cout << "Unit test invalid URLs for Url.h" << endl;
                 const vector<string> invalid_urls { "://server.com",
@@ -50,7 +71,10 @@ namespace iot {
                                                     "http://:@server.com:3128",
                                                     "http://:1@server.com:3128",
                                                     "http://1:@server.com:3128",
-                                                    "http://server.com:abs" };
+                                                    "http://server.com:abs",
+                                                    "http://server.com:70000",
+                                                    "http://server.com:99999",
+                                                    "http://[::1:8080" };
                 for (auto invalid_url : invalid_urls) {
                     REQUIRE_THROWS_AS(
                         [&]() {
@@ -79,7 +103,8 @@ namespace iot {
                 cout << "Unit tests for url_decode-invalid case" << endl;
                 const vector<string> invalid_url_codes { "%%",  "%",
                                                          "%gh", "%h1",
-                                                         "%x2", "121fad%1" };
+                                                         "%x2", "121fad%1",
+                                                         "%00", "abc%00def" };
                 for (const auto &invalid_url_code : invalid_url_codes) {
                     REQUIRE_THROWS_AS(
                         [&]() {


### PR DESCRIPTION
### Motivation
Did some local investigations and packaged some of the fixes together. A manual
review plus static/dynamic analysis (cppcheck, clang-tidy, valgrind) of the
local proxy surfaced one data-corruption bug, several memory/lifetime leaks, a
data race, and a few input-hardening gaps. This change bundles those fixes — one
self-contained commit per issue, each with its own formatting, and with unit
tests and docs updated where behaviour changed.

### Modifications

#### Change summary

| # | Commit | Area | Change |
|---|--------|------|--------|
| 1 | `209a127` | `TcpAdapterProxy.cpp` | **Data corruption (critical):** the TCP write-drain completion handler was a function-local `static std::function` shared across all connections, so a completion could run another connection's lambda and write to the wrong socket. Replaced with a per-call, heap-allocated self-owning `shared_ptr<std::function>` handler; the self-reference cycle is broken on every terminal path so it frees when the write loop ends. |
| 2 | `6cf9415` | `WebProxyAdapter.cpp` | **Double callback + leak:** the HTTP CONNECT read handler missed a `return` on the error path and invoked the completion handler twice; the response buffer (`new char[]`) leaked on the exception path. Added the early return and switched to a `shared_ptr<vector<char>>` (RAII on all paths). |
| 3 | `6391014` | `TcpAdapterProxy.cpp` | **Reference-cycle leak:** `basic_retry_config` bound its own `shared_ptr` into its `operation` field at three sites, so the object (and its timer) never freed. Capture a `weak_ptr` and `lock()` it instead — safe because the retry timer already holds a strong ref while `operation()` runs. |
| 4 | `8b1488a` | `TcpAdapterProxy.cpp` | **Data race + null call:** `outgoing_message_queue.front()` was read without the mutex guarding `push()`/`pop()`; and `on_receive_stream_start` (never assigned) threw `std::bad_function_call` on every new stream. Read `front()` under the mutex with an empty guard, and null-check the callback. |
| 5 | `f6ea004` | `main.cpp`, `Url.cpp`, `WebSocketStream.cpp`, `test/Url.cpp` | **Input/TLS hardening:** range-check ports to `[0, 65535]` (no silent `uint16_t` truncation) and handle `out_of_range`; bracket-aware IPv6 parsing for the web-proxy URL; reject `%00` in `url_decode`; restrict the SSL context to **TLS 1.2+** (disable SSLv2/3, TLS 1.0/1.1). Adds Url tests for the new cases. |
| 6 | `6497553` | `README.md` | **Docs:** note the TLS 1.2+ requirement (OpenSSL 1.0.1+/3) and that the web-proxy URL now accepts a bracketed IPv6 literal, while other `address:port` args remain IPv4-only. |
| 7 | `a2d9e8f` | `AGENTS.md` | **Docs:** for agents to commit to the repo|

Please describe what changes are included in this pull request.

#### Revision diff summary

If there is more than one revision, please explain what has been changed since
the last revision.

### Testing

**Is your change tested? If not, please justify the reason.**  
 **Please list your testing steps and test results.**

- CI test run result: <link>

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
