### PR TITLE
Add UATs test for multiplex integrity

### DIFF
--- a/.github/workflows/uat-and-release.yml
+++ b/.github/workflows/uat-and-release.yml
@@ -114,6 +114,7 @@ jobs:
           ./uat/run_uat.sh
           ./uat/test_lifecycle.sh
           ./uat/test_multiport.sh
+          ./uat/test_multiplex_integrity.sh
           ./uat/test_v1_compat.sh
           ./uat/test_ssh_connectivity.sh
 
@@ -228,6 +229,7 @@ jobs:
               ./uat/run_uat.sh
               ./uat/test_lifecycle.sh
               ./uat/test_multiport.sh
+              ./uat/test_multiplex_integrity.sh
               ./uat/test_v1_compat.sh
             '
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,13 @@ overall contribution policy (issues, PRs, CLA).
 Before every commit:
 
 1. Make one focused, logical change.
-2. `nix fmt` — format the tree (must end clean / idempotent).
-3. Build and run the unit tests (see below); ensure they pass.
-4. Stage only the files for this change; write a clear message (see below).
-5. Never commit to `main`; never force-push a shared branch without
+2. Update the unit tests and UATs the change affects (see below).
+3. `nix fmt` — format the tree (must end clean / idempotent).
+4. Run the spelling check (see Spelling); add legitimate technical terms to
+   `misc/dictionary.txt` if flagged.
+5. Build and run the unit tests (see below); ensure they pass.
+6. Stage only the files for this change; write a clear message (see below).
+7. Never commit to `main`; never force-push a shared branch without
    coordinating.
 
 ---
@@ -37,6 +40,9 @@ Before every commit:
   Don't mix unrelated changes.
 - Keep the **tests** and **docs** for a change in the same commit as the change
   (e.g. URL-parsing tests live with the URL-parsing fix).
+- With each feature or fix, update the **unit tests** (`test/`, Catch2) and the
+  **UATs** (`uat/`) as needed so behavior stays covered: add cases for new
+  behavior and adjust existing ones instead of deleting them.
 - Keep **formatting** in the same commit as the code it applies to. Normally
   this is automatic: just run `nix fmt` _before_ committing. (Redistributing
   formatting across already-made commits is only needed if it was applied after
@@ -83,6 +89,9 @@ make -j"$(nproc)"
 - With `-DBUILD_TESTS=ON`, the Catch2 test binary is `build/bin/localproxytest`;
   run it to execute the unit suite. Ensure all tests pass before committing.
 - Build directories matching `*build*/` are git-ignored.
+- The end-to-end UATs live in `uat/` (see `uat/README.md`); run the relevant
+  scripts when a change affects tunnel/proxy behavior, and keep them current
+  with the feature.
 
 Relevant CMake options (top of `CMakeLists.txt`):
 
@@ -106,9 +115,24 @@ Relevant CMake options (top of `CMakeLists.txt`):
   run those tools. There are no committed wrapper scripts — run any such tools
   directly.
 
+## Spelling
+
+- A cspell spelling check runs in CI and can be run via the flake:
+  ```bash
+  nix build -L .#checks.<system>.spelling   # e.g. x86_64-linux, aarch64-linux
+  ```
+- It scans code, comments, and docs. If it flags a legitimate technical term
+  (tool name, CLI flag, identifier), add it to the allowlist
+  `misc/dictionary.txt` (kept sorted; cspell matches case-insensitively) rather
+  than rewording the term. Don't allowlist genuine misspellings — fix those
+  instead.
+
 ## Code conventions / gotchas
 
 - C++14. Preserve existing comments and `BOOST_LOG_SEV` logging statements.
+- Keep comments concise and logical: explain the _why_ (non-obvious intent,
+  invariants, lifetime/ownership, gotchas), not the obvious _what_. Prefer a
+  short comment over a verbose block, and don't restate the code.
 - Prefer RAII (`shared_ptr`/`unique_ptr`, `lock_guard`) over raw `new`/`delete`
   and manual unlocking.
 - **Boost.Asio handler lifetime:** async completion handlers must outlive the
@@ -126,7 +150,8 @@ Relevant CMake options (top of `CMakeLists.txt`):
 ## Do / don't
 
 - DO keep commits small, buildable, and individually reviewable.
-- DO run `nix fmt`, build, and tests before committing.
+- DO run `nix fmt`, the spelling check, build, and unit tests/UATs before
+  committing.
 - DON'T weaken or delete tests to make a build pass — fix the code.
 - DON'T commit to `main` or force-push shared branches without coordination.
 - DON'T strip comments/logging or expand a commit's scope beyond its stated fix.

--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -16,6 +16,7 @@ DWIN
 fasdbla
 gnueabihf
 hrfth
+infile
 iotsecuretunneling
 localproxy
 lpsettings
@@ -25,7 +26,10 @@ MVNKV
 mxyo
 Myho
 NASM
+ncat
 nmake
+nmap
+pids
 pkgs
 RAII
 Rjnmc
@@ -35,6 +39,7 @@ sslv
 stoi
 treefmt
 Uhdrl
+urandom
 VQZH
 Vugzrm
 xzvf

--- a/src/TcpAdapterProxy.cpp
+++ b/src/TcpAdapterProxy.cpp
@@ -2561,32 +2561,22 @@ namespace iot {
                     connection->on_tcp_write_buffer_drain_complete
                 );
             } else {
-                // Self-owning handler via shared_ptr: constructed only when an
-                // async write is actually initiated. The lambda captures the
-                // shared_ptr by value so the handler outlives
-                // async_tcp_write_buffer_drain's stack frame. The
-                // self-reference cycle (shared_ptr -> std::function -> captures
-                // shared_ptr) is broken on every terminal path by clearing the
-                // stored std::function, which drops the captured shared_ptr
-                // copy.
-                auto write_done = std::make_shared<std::function<
-                    void(const boost::system::error_code &, size_t)>>();
-                *write_done = [this,
-                               &tac,
-                               service_id,
-                               connection_id,
-                               write_done](
-                                  const boost::system::error_code &ec,
-                                  size_t bytes_written
-                              ) {
+                // Owned by the connection so it is freed with the connection;
+                // captures only ids/context, so there is no ownership cycle.
+                connection->write_done = [this,
+                                          &tac,
+                                          service_id,
+                                          connection_id](
+                                             const boost::system::error_code
+                                                 &ec,
+                                             size_t bytes_written
+                                         ) {
                     BOOST_LOG_SEV(log, trace)
                         << "write done service id " << service_id
                         << ", connection id: " << connection_id;
                     tcp_connection::pointer socket_write_connection
                         = get_tcp_connection(tac, service_id, connection_id);
                     if (!socket_write_connection) {
-                        // Terminal path: break self-reference cycle
-                        *write_done = nullptr;
                         return;
                     }
                     socket_write_connection->is_tcp_socket_writing_ = false;
@@ -2599,8 +2589,6 @@ namespace iot {
                                 tac, ec, service_id, connection_id
                             );
                         }
-                        // Terminal path: break self-reference cycle
-                        *write_done = nullptr;
                     } else {
                         BOOST_LOG_SEV(log, trace)
                             << "Wrote " << bytes_written
@@ -2626,7 +2614,6 @@ namespace iot {
                                    "loop";
                             async_web_socket_read_loop(tac);
                         }
-                        bool rearmed = false;
                         if (socket_write_connection->tcp_write_buffer_.size()
                             > 0) {
                             socket_write_connection->is_tcp_socket_writing_
@@ -2635,9 +2622,8 @@ namespace iot {
                             socket_write_connection->socket_.async_write_some(
                                 socket_write_connection->tcp_write_buffer_
                                     .data(),
-                                *write_done
+                                socket_write_connection->write_done
                             );
-                            rearmed = true;
                         } else {
                             if (socket_write_connection
                                     ->on_tcp_write_buffer_drain_complete) {
@@ -2652,15 +2638,11 @@ namespace iot {
                         BOOST_LOG_SEV(log, trace)
                             << "Done writing for: " << service_id
                             << ", connection id: " << connection_id;
-                        if (!rearmed) {
-                            // Terminal path: break self-reference cycle
-                            *write_done = nullptr;
-                        }
                     }
                 };
                 connection->is_tcp_socket_writing_ = true;
                 connection->socket_.async_write_some(
-                    connection->tcp_write_buffer_.data(), *write_done
+                    connection->tcp_write_buffer_.data(), connection->write_done
                 );
             }
         }

--- a/src/TcpConnection.h
+++ b/src/TcpConnection.h
@@ -104,6 +104,11 @@ namespace iot {
                 // web_socket_data_write_buffer_ drain has completed
                 std::function<void()> on_web_socket_write_buffer_drain_complete
                     = nullptr;
+                // Chained async TCP write-buffer drain handler, owned by the
+                // connection so it is freed with it.
+                std::function<
+                    void(const boost::system::error_code &, std::size_t)>
+                    write_done = nullptr;
             };
         }
     }

--- a/uat/README.md
+++ b/uat/README.md
@@ -55,13 +55,14 @@ chmod +x *.sh
 
 ## Test Scripts
 
-| Script                     | Description                                                           |
-| -------------------------- | --------------------------------------------------------------------- |
-| `run_uat.sh`               | Main E2E test: opens tunnel, starts both proxies, verifies connection |
-| `test_lifecycle.sh`        | Tests AWS API operations: open, describe, list, rotate, close         |
-| `test_v1_compat.sh`        | Tests V1 backward compatibility with `--destination-client-type V1`   |
-| `test_multiport.sh`        | Tests multi-port tunneling with multiple service IDs                  |
-| `test_ssh_connectivity.sh` | Tests SSH through tunnel (key-based and password-based auth)          |
+| Script                        | Description                                                                                                                                                                                               |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_uat.sh`                  | Main E2E test: opens tunnel, starts both proxies, verifies connection                                                                                                                                     |
+| `test_lifecycle.sh`           | Tests AWS API operations: open, describe, list, rotate, close                                                                                                                                             |
+| `test_v1_compat.sh`           | Tests V1 backward compatibility with `--destination-client-type V1`                                                                                                                                       |
+| `test_multiport.sh`           | Tests multi-port tunneling with multiple service IDs                                                                                                                                                      |
+| `test_ssh_connectivity.sh`    | Tests SSH through tunnel (key-based and password-based auth)                                                                                                                                              |
+| `test_multiplex_integrity.sh` | Multiplexes several services over ONE tunnel, transfers a distinct random payload through each one concurrently, and verifies byte-for-byte integrity (sha256) with cross-service contamination detection |
 
 ## Configuration
 
@@ -74,6 +75,16 @@ chmod +x *.sh
 | `SSH_PASS`    | Yes      | -              | SSH password (`test_ssh_connectivity.sh`) |
 | `SSH_KEY`     | No       | ~/.ssh/id_rsa  | SSH private key path                      |
 | `SSH_USER`    | No       | current user   | SSH username                              |
+
+### `test_multiplex_integrity.sh` variables
+
+| Variable           | Required | Default             | Description                                              |
+| ------------------ | -------- | ------------------- | -------------------------------------------------------- |
+| `SERVICES`         | No       | `DATA1 DATA2 DATA3` | Space-separated service IDs multiplexed over one tunnel  |
+| `SRC_PORT_BASE`    | No       | 6001                | First source-proxy listen port (incremented per service) |
+| `DST_PORT_BASE`    | No       | 7001                | First destination service port (incremented per service) |
+| `FILE_SIZE`        | No       | 131072 (128 KiB)    | Random bytes transferred per service                     |
+| `TRANSFER_TIMEOUT` | No       | 60                  | Per-transfer timeout in seconds                          |
 
 ## Examples
 
@@ -90,6 +101,12 @@ SSH_PASS=password ./test_ssh_connectivity.sh
 
 # SSH connectivity with key
 SSH_KEY=~/.ssh/my_key SSH_USER=ubuntu ./test_ssh_connectivity.sh
+
+# Multiplexed tunnel + file-transfer integrity (default 3 services, 128 KiB each)
+./test_multiplex_integrity.sh
+
+# Multiplex integrity with custom services and larger payloads
+SERVICES="A B C D" FILE_SIZE=20971520 ./test_multiplex_integrity.sh
 ```
 
 ## Logs
@@ -98,12 +115,13 @@ All logs are stored in the `uat/logs/` directory (created automatically on test
 run). Each test script redirects localproxy stdout/stderr to log files with
 test-specific prefixes:
 
-| Test Script                | Log Files                                                                            |
-| -------------------------- | ------------------------------------------------------------------------------------ |
-| `run_uat.sh`               | `source_proxy.log`, `dest_proxy.log`                                                 |
-| `test_v1_compat.sh`        | `v1_source.log`                                                                      |
-| `test_multiport.sh`        | `multiport_source.log`, `multiport_dest.log`                                         |
-| `test_ssh_connectivity.sh` | `ssh_key_source.log`, `ssh_key_dest.log`, `ssh_pass_source.log`, `ssh_pass_dest.log` |
+| Test Script                   | Log Files                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `run_uat.sh`                  | `source_proxy.log`, `dest_proxy.log`                                                 |
+| `test_v1_compat.sh`           | `v1_source.log`                                                                      |
+| `test_multiport.sh`           | `multiport_source.log`, `multiport_dest.log`                                         |
+| `test_multiplex_integrity.sh` | `multiplex_source.log`, `multiplex_dest.log`                                         |
+| `test_ssh_connectivity.sh`    | `ssh_key_source.log`, `ssh_key_dest.log`, `ssh_pass_source.log`, `ssh_pass_dest.log` |
 
 Logs are overwritten on each test run. Verbosity is set to `-v 5` (debug level)
 by default.

--- a/uat/test_multiplex_integrity.sh
+++ b/uat/test_multiplex_integrity.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# UAT: Multiplexed tunnel establishment + file-transfer integrity
+#
+# Opens a SINGLE AWS IoT secure tunnel that carries MULTIPLE services
+# (multiplexing), then pushes a distinct random payload through every service
+# CONCURRENTLY and verifies each payload arrives byte-for-byte intact (sha256)
+# on its own service with no cross-service contamination.
+#
+# This exercises the multiplexer end-to-end and would catch data-corruption
+# regressions where one connection's bytes leak into another (e.g. the
+# historical shared `static write_done` handler bug).
+#
+# Exit codes: 0=pass, 1=fail
+# shellcheck shell=bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/common.sh"
+
+LOCALPROXY="${SCRIPT_DIR}/../build/bin/localproxy"
+REGION="${AWS_REGION:-us-east-1}"
+THING_NAME="uat-multiplex-$(date +%s)-$$"
+
+# Space-separated service IDs multiplexed over ONE tunnel (configurable).
+read -r -a SERVICES <<<"${SERVICES:-DATA1 DATA2 DATA3}"
+SRC_PORT_BASE="${SRC_PORT_BASE:-6001}" # source proxy listen ports start here
+DST_PORT_BASE="${DST_PORT_BASE:-7001}" # destination service ports start here
+FILE_SIZE="${FILE_SIZE:-131072}"       # bytes of random data per service (128 KiB)
+TRANSFER_TIMEOUT="${TRANSFER_TIMEOUT:-60}"
+WORK_DIR="$(mktemp -d)"
+
+declare -A SVC_SRC_PORT SVC_DST_PORT
+declare -A SEND_SUM RECV_SUM
+
+THING_CREATED=""
+TUNNEL_ID=""
+SOURCE_PID=""
+DEST_PID=""
+LISTENER_PIDS=()
+
+cleanup() {
+  log_info "Cleaning up..."
+  for pid in "${LISTENER_PIDS[@]}"; do
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+  done
+  if [[ -n "$SOURCE_PID" ]]; then
+    kill "$SOURCE_PID" 2>/dev/null
+    wait "$SOURCE_PID" 2>/dev/null || log_error "Failed to stop source proxy"
+  fi
+  if [[ -n "$DEST_PID" ]]; then
+    kill "$DEST_PID" 2>/dev/null
+    wait "$DEST_PID" 2>/dev/null || log_error "Failed to stop destination proxy"
+  fi
+  if [[ -n "$TUNNEL_ID" ]]; then
+    aws iotsecuretunneling close-tunnel --tunnel-id "$TUNNEL_ID" --delete --region "$REGION" 2>/dev/null \
+      && log_info "Deleted tunnel: $TUNNEL_ID" \
+      || log_error "Failed to close tunnel: $TUNNEL_ID"
+  fi
+  if [[ -n "$THING_CREATED" ]]; then
+    aws iot delete-thing --thing-name "$THING_NAME" --region "$REGION" 2>/dev/null \
+      && log_info "Deleted thing: $THING_NAME" \
+      || log_error "Failed to delete thing: $THING_NAME"
+  fi
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# ---- netcat flavor handling --------------------------------------------------
+# nc syntax differs across implementations; detect once and adapt.
+NC_FLAVOR=""
+detect_nc() {
+  check_command nc
+  local help
+  help="$(nc -h 2>&1 || true)"
+  if printf '%s' "$help" | grep -qi 'ncat'; then
+    NC_FLAVOR="ncat" # nmap ncat: `nc -l PORT`, closes on stdin EOF
+  elif printf '%s' "$help" | grep -q -- '-N'; then
+    NC_FLAVOR="openbsd" # netcat-openbsd: `nc -l PORT`, `-N` half-closes on EOF
+  else
+    NC_FLAVOR="traditional" # GNU/traditional: `nc -l -p PORT`, `-q 0` quits on EOF
+  fi
+  log_info "Detected netcat flavor: $NC_FLAVOR"
+}
+
+# nc_listen <port> <outfile> : accept one connection, write payload to file.
+nc_listen() {
+  local port="$1" out="$2"
+  case "$NC_FLAVOR" in
+    traditional) timeout "$TRANSFER_TIMEOUT" nc -l -p "$port" >"$out" 2>/dev/null ;;
+    *) timeout "$TRANSFER_TIMEOUT" nc -l "$port" >"$out" 2>/dev/null ;;
+  esac
+}
+
+# nc_send <port> <infile> : connect to source proxy port, stream file, close.
+nc_send() {
+  local port="$1" in="$2"
+  case "$NC_FLAVOR" in
+    openbsd) timeout "$TRANSFER_TIMEOUT" nc -N 127.0.0.1 "$port" <"$in" 2>/dev/null ;;
+    traditional) timeout "$TRANSFER_TIMEOUT" nc -q 0 127.0.0.1 "$port" <"$in" 2>/dev/null ;;
+    ncat) timeout "$TRANSFER_TIMEOUT" nc 127.0.0.1 "$port" <"$in" 2>/dev/null ;;
+  esac
+}
+
+# ---- setup helpers -----------------------------------------------------------
+check_prerequisites() {
+  log_info "Checking prerequisites..."
+  check_command aws
+  check_command jq
+  check_command sha256sum
+  detect_nc
+  check_localproxy "$LOCALPROXY"
+  check_aws_credentials
+  if [[ "${#SERVICES[@]}" -lt 2 ]]; then
+    log_error "Multiplex test needs at least 2 services (got ${#SERVICES[@]})"
+    exit 1
+  fi
+}
+
+create_thing() {
+  log_info "Creating IoT thing: $THING_NAME"
+  aws iot create-thing --thing-name "$THING_NAME" --region "$REGION" >/dev/null || {
+    log_error "Failed to create thing"
+    exit 1
+  }
+  THING_CREATED=1
+}
+
+build_service_maps() {
+  DST_MAP=""
+  SRC_MAP=""
+  local i=0 svc src dst
+  for svc in "${SERVICES[@]}"; do
+    src=$((SRC_PORT_BASE + i))
+    dst=$((DST_PORT_BASE + i))
+    SVC_SRC_PORT["$svc"]=$src
+    SVC_DST_PORT["$svc"]=$dst
+    DST_MAP+="${svc}=127.0.0.1:${dst},"
+    SRC_MAP+="${svc}=${src},"
+    i=$((i + 1))
+  done
+  DST_MAP="${DST_MAP%,}"
+  SRC_MAP="${SRC_MAP%,}"
+  log_info "Destination map: $DST_MAP"
+  log_info "Source map:      $SRC_MAP"
+}
+
+open_tunnel() {
+  local svc_csv
+  svc_csv=$(
+    IFS=,
+    echo "${SERVICES[*]}"
+  )
+  log_info "Opening multiplexed tunnel in $REGION (services=$svc_csv)..."
+  local out
+  out=$(aws iotsecuretunneling open-tunnel \
+    --destination-config "thingName=$THING_NAME,services=$svc_csv" \
+    --region "$REGION" --output json)
+  TUNNEL_ID=$(echo "$out" | jq -r '.tunnelId')
+  SOURCE_TOKEN=$(echo "$out" | jq -r '.sourceAccessToken')
+  DEST_TOKEN=$(echo "$out" | jq -r '.destinationAccessToken')
+  [[ -z "$TUNNEL_ID" || "$TUNNEL_ID" == "null" ]] && {
+    log_error "Failed to open tunnel"
+    exit 1
+  }
+  log_info "Tunnel opened: $TUNNEL_ID"
+}
+
+start_proxies() {
+  log_info "Starting destination proxy..."
+  AWSIOT_TUNNEL_ACCESS_TOKEN="$DEST_TOKEN" "$LOCALPROXY" \
+    -r "$REGION" -d "$DST_MAP" -v 5 \
+    >"${LOG_DIR}/multiplex_dest.log" 2>&1 &
+  DEST_PID=$!
+
+  log_info "Starting source proxy..."
+  AWSIOT_TUNNEL_ACCESS_TOKEN="$SOURCE_TOKEN" "$LOCALPROXY" \
+    -r "$REGION" -s "$SRC_MAP" -b 127.0.0.1 -v 5 \
+    >"${LOG_DIR}/multiplex_source.log" 2>&1 &
+  SOURCE_PID=$!
+}
+
+# Test 1: both proxies establish the multiplexed websocket session.
+test_establishment() {
+  log_info "=== Test 1: Multiplexed tunnel establishment ==="
+  if wait_for_log "${LOG_DIR}/multiplex_dest.log" "Successfully established websocket connection" 15 \
+    && wait_for_log "${LOG_DIR}/multiplex_source.log" "Successfully established websocket connection" 15; then
+    log_info "Establishment test PASSED"
+    return 0
+  fi
+  log_error "Establishment test FAILED"
+  log_error "--- dest log tail ---"
+  tail -20 "${LOG_DIR}/multiplex_dest.log" 2>/dev/null || true
+  log_error "--- source log tail ---"
+  tail -20 "${LOG_DIR}/multiplex_source.log" 2>/dev/null || true
+  return 1
+}
+
+# Test 2: concurrent file transfer through every service + integrity check.
+test_integrity() {
+  log_info "=== Test 2: Concurrent multiplexed file-transfer integrity ==="
+
+  # Generate a distinct random payload per service and record its checksum.
+  local svc
+  for svc in "${SERVICES[@]}"; do
+    head -c "$FILE_SIZE" /dev/urandom >"${WORK_DIR}/send_${svc}.bin"
+    SEND_SUM["$svc"]=$(sha256sum "${WORK_DIR}/send_${svc}.bin" | awk '{print $1}')
+  done
+  log_info "Generated ${#SERVICES[@]} payloads of ${FILE_SIZE} bytes each"
+
+  # Start a receiver on every destination service port BEFORE sending.
+  for svc in "${SERVICES[@]}"; do
+    nc_listen "${SVC_DST_PORT[$svc]}" "${WORK_DIR}/recv_${svc}.bin" &
+    LISTENER_PIDS+=("$!")
+  done
+  sleep 2 # let listeners bind
+
+  # Fire all transfers CONCURRENTLY to exercise the multiplexer.
+  local send_pids=()
+  for svc in "${SERVICES[@]}"; do
+    nc_send "${SVC_SRC_PORT[$svc]}" "${WORK_DIR}/send_${svc}.bin" &
+    send_pids+=("$!")
+  done
+  log_info "Launched ${#send_pids[@]} concurrent transfers; waiting for completion..."
+  for pid in "${send_pids[@]}"; do wait "$pid" 2>/dev/null || true; done
+  for pid in "${LISTENER_PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
+
+  # Verify integrity + detect cross-service contamination.
+  local failed=0
+  for svc in "${SERVICES[@]}"; do
+    local recv="${WORK_DIR}/recv_${svc}.bin"
+    if [[ ! -s "$recv" ]]; then
+      log_error "[$svc] no data received"
+      failed=$((failed + 1))
+      continue
+    fi
+    RECV_SUM["$svc"]=$(sha256sum "$recv" | awk '{print $1}')
+    local recv_size send_size
+    recv_size=$(wc -c <"$recv")
+    send_size=$(wc -c <"${WORK_DIR}/send_${svc}.bin")
+
+    if [[ "${RECV_SUM[$svc]}" == "${SEND_SUM[$svc]}" ]]; then
+      log_info "[$svc] integrity OK (${recv_size} bytes, sha256 match)"
+    else
+      log_error "[$svc] integrity FAILED (sent ${send_size} bytes / recv ${recv_size} bytes; sha256 mismatch)"
+      failed=$((failed + 1))
+      # Cross-talk detection: did this service receive ANOTHER service's payload?
+      local other
+      for other in "${SERVICES[@]}"; do
+        [[ "$other" == "$svc" ]] && continue
+        if [[ "${RECV_SUM[$svc]}" == "${SEND_SUM[$other]}" ]]; then
+          log_error "[$svc] CROSS-TALK: received payload intended for [$other] (multiplexer data corruption)"
+        fi
+      done
+    fi
+  done
+
+  if [[ $failed -eq 0 ]]; then
+    log_info "Integrity test PASSED for all ${#SERVICES[@]} services"
+    return 0
+  fi
+  log_error "Integrity test FAILED for $failed/${#SERVICES[@]} services"
+  return 1
+}
+
+main() {
+  log_info "Testing multiplexed tunnel + file-transfer integrity..."
+  check_prerequisites
+  create_thing
+  build_service_maps
+  open_tunnel
+  start_proxies
+
+  local passed=0 failed=0
+  for t in test_establishment test_integrity; do
+    if $t; then passed=$((passed + 1)); else failed=$((failed + 1)); fi
+  done
+
+  echo ""
+  log_info "=== UAT Results (multiplex integrity) ==="
+  log_info "Passed: $passed, Failed: $failed"
+  [[ $failed -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation

This PR contains two related changes:

- The existing UATs only confirm that the websocket session establishes — none
  push real data through a **multiplexed** tunnel or verify that it arrives
  intact. This adds an end-to-end test that transfers data across several
  services on one tunnel concurrently and checks integrity, so cross-connection
  data corruption in the multiplexer would be caught.
- While validating that test, the TCP write-buffer drain handler was reworked
  for clearer ownership (details below).

- Issue number: N/A

### Modifications

#### Change summary

**Multiplexed integrity UAT**

- **New `uat/test_multiplex_integrity.sh`** — opens a single tunnel carrying
  multiple services, pushes a distinct random payload through each one
  concurrently, and verifies per-service `sha256` integrity with explicit
  cross-talk detection (flags if one service receives another's bytes). Reuses
  `lib/common.sh` helpers and the existing cleanup-trap pattern, detects the
  installed `nc` flavor, and guards every transfer with timeouts. The source
  proxy binds IPv4 (`-b 127.0.0.1`) because GitHub-hosted runners are
  IPv4-only, and the payload size / timeout are tuned to the tunnel's
  throughput. Configurable via `SERVICES`, `SRC_PORT_BASE`, `DST_PORT_BASE`,
  `FILE_SIZE`, and `TRANSFER_TIMEOUT`.
- **`.github/workflows/uat-and-release.yml`** — wire the new script into both
  the multi-arch (x86_64 / aarch64) `build` job and the ARM32 job.
- **`uat/README.md`** — document the test, its environment variables, an example
  invocation, and its log files.
- **`misc/dictionary.txt`** — add the technical terms the test uses (`infile`,
  `ncat`, `nmap`, `pids`, `urandom`) to the cspell allowlist so the spelling
  check passes.

**TCP write-drain handler ownership**

- **`src/TcpAdapterProxy.cpp` / `src/TcpConnection.h`** — store the TCP
  write-buffer drain handler as a `tcp_connection` member instead of a
  self-owning `shared_ptr<std::function>` that captured itself. Its lifetime is
  now tied to the connection (freed when the connection is destroyed), and the
  lambda captures only ids/context — removing the ownership cycle and the manual
  clearing of the handler on every terminal path. Behavior-preserving.

#### Revision diff summary

Since the description was first written: added the `tcp_connection`-owned
write-drain handler refactor (`src/TcpAdapterProxy.cpp`, `src/TcpConnection.h`),
the cspell allowlist entries (`misc/dictionary.txt`), and documented the IPv4
source bind and throughput-based payload sizing in the test.

### Testing

**Is your change tested? If not, please justify the reason.**  
**Please list your testing steps and test results.**

Yes.

- The test runs against a real AWS IoT secure tunnel and passes only when every
  concurrent per-service transfer arrives byte-for-byte intact:

  ```bash
  cd uat && ./test_multiplex_integrity.sh
  ```

- `bash -n` syntax check passes; the cspell spelling check
  (`nix build .#checks.<arch>.spelling`) passes with the added dictionary terms.
- The write-drain handler refactor is behavior-preserving and is exercised by
  the multiplexed integrity test.
- **CI:** `.github/workflows/uat-and-release.yml` runs the test as part of the
  full UAT suite across x86_64, aarch64, and ARM32 on every push and PR.

- CI test run result: see the **Checks** tab on this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
